### PR TITLE
WFSSL-15: Enabling one-way ssl using elytron with key length < 2048 returns non user friendly error message

### DIFF
--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketTest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketTest.java
@@ -43,18 +43,19 @@ public class BasicOpenSSLSocketTest extends AbstractOpenSSLTest {
             Thread acceptThread = new Thread(new EchoRunnable(serverSocket, SSLTestUtils.createSSLContext("TLSv1"), sessionID));
             acceptThread.start();
             final SSLContext sslContext = SSLTestUtils.createClientSSLContext("openssl.TLSv1");
-            final SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
-            socket.connect(SSLTestUtils.createSocketAddress());
-            socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
-            socket.getOutputStream().flush();
-            byte[] data = new byte[100];
-            int read = socket.getInputStream().read(data);
+            try (final SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket()) {
+                socket.connect(SSLTestUtils.createSocketAddress());
+                socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
+                socket.getOutputStream().flush();
+                byte[] data = new byte[100];
+                int read = socket.getInputStream().read(data);
 
-            Assert.assertEquals("hello world", new String(data, 0, read));
-            //TODO: fix client session id
-            //Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
-            serverSocket.close();
-            acceptThread.join();
+                Assert.assertEquals("hello world", new String(data, 0, read));
+                //TODO: fix client session id
+                //Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+                serverSocket.close();
+                acceptThread.join();
+            }
         }
     }
 
@@ -68,17 +69,18 @@ public class BasicOpenSSLSocketTest extends AbstractOpenSSLTest {
             acceptThread.start();
             final SSLContext sslContext = SSLTestUtils.createClientSSLContext("openssl.TLSv1");
             InetSocketAddress socketAddress = (InetSocketAddress) SSLTestUtils.createSocketAddress();
-            final SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket(socketAddress.getAddress(), socketAddress.getPort());
-            socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
-            socket.getOutputStream().flush();
-            byte[] data = new byte[100];
-            int read = socket.getInputStream().read(data);
+            try (final SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket(socketAddress.getAddress(), socketAddress.getPort())) {
+                socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
+                socket.getOutputStream().flush();
+                byte[] data = new byte[100];
+                int read = socket.getInputStream().read(data);
 
-            Assert.assertEquals("hello world", new String(data, 0, read));
-            //TODO: fix client session id
-            //Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
-            serverSocket.close();
-            acceptThread.join();
+                Assert.assertEquals("hello world", new String(data, 0, read));
+                //TODO: fix client session id
+                //Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+                serverSocket.close();
+                acceptThread.join();
+            }
         }
     }
 }

--- a/libwfssl/include/wfssl.h
+++ b/libwfssl/include/wfssl.h
@@ -347,6 +347,12 @@ typedef  unsigned __int64   uint64_t;
 #define SSL_INFO_SERVER_CERT                (0x0207)
 #define SSL_INFO_CLIENT_CERT_CHAIN          (0x0400)
 
+/* Defines for BIO */
+
+# define BIO_CTRL_INFO           3/* opt - extra tit-bits */
+
+# define BIO_get_mem_data(b,pp)  crypto_methods.BIO_ctrl(b,BIO_CTRL_INFO,0,(char *)(pp))
+
 /*  Use "weak" to redeclare optional features */
 #define weak __attribute__((weak))
 
@@ -601,6 +607,7 @@ typedef struct {
     void (*CRYPTO_set_locking_callback)(void (*func) (int mode, int type,const char *file,int line));
     int (*CRYPTO_set_mem_functions)(void *(*m)(size_t),void *(*r)(void *,size_t), void (*f)(void *));
     char *(*ERR_error_string)(unsigned long e, char *buf);
+    void (*ERR_print_errors)(BIO *bp);
 
     unsigned long (*ERR_get_error)(void);
     void (*ERR_load_crypto_strings)(void);
@@ -653,6 +660,7 @@ typedef struct {
     DH *(*PEM_read_bio_DHparams)(BIO *bp, DH **x, pem_password_cb *cb, void *u);
 } crypto_dynamic_methods;
 
+void generate_openssl_stack_error(JNIEnv *e, char *buf, long len);
 void tcn_Throw(JNIEnv *env, char *fmt, ...);
 jint throwIllegalStateException( JNIEnv *env, char *message);
 jint throwIllegalArgumentException( JNIEnv *env, char *message);

--- a/libwfssl/src/session.c
+++ b/libwfssl/src/session.c
@@ -257,7 +257,9 @@ WF_OPENSSL(void, setSession)(JNIEnv *e, jobject o, jlong ssl, jlong session)
     }
     r = ssl_methods.SSL_set_session(ssl_, session_);
     if (r == 0) {
-        fprintf(stderr, "org.wildfly.openssl [ERROR] %s", crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), NULL));
+        char err[2048];
+        generate_openssl_stack_error(e, err, sizeof(err));
+        tcn_Throw(e, "Error setting the session (%s)", err);
     }
 }
 

--- a/libwfssl/src/ssl.c
+++ b/libwfssl/src/ssl.c
@@ -400,6 +400,7 @@ int load_openssl_dynamic_methods(JNIEnv *e, const char * libCryptoPath, const ch
     GET_CRYPTO_SYMBOL(CRYPTO_set_locking_callback);
     REQUIRE_CRYPTO_SYMBOL(CRYPTO_set_mem_functions);
     REQUIRE_CRYPTO_SYMBOL(ERR_error_string);
+    REQUIRE_CRYPTO_SYMBOL(ERR_print_errors);
     REQUIRE_CRYPTO_SYMBOL(ERR_get_error);
     GET_CRYPTO_SYMBOL(ERR_load_crypto_strings);
     GET_CRYPTO_SYMBOL(OPENSSL_add_all_algorithms_noconf);
@@ -452,7 +453,6 @@ int load_openssl_dynamic_methods(JNIEnv *e, const char * libCryptoPath, const ch
 
     return 0;
 }
-
 
 WF_OPENSSL(jint, initialize) (JNIEnv *e, jobject o, jstring libCryptoPath, jstring libSSLPath) {
 #pragma comment(linker, "/EXPORT:"__FUNCTION__"="__FUNCDNAME__)
@@ -545,8 +545,8 @@ WF_OPENSSL(jlong, makeSSLContext)(JNIEnv *e, jobject o, jint protocol, jint mode
             ctx = ssl_methods.SSL_CTX_new(ssl_methods.SSLv23_method());
     }
     if (!ctx) {
-        char err[256];
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        char err[2048];
+        generate_openssl_stack_error(e, err, sizeof(err));
         throwIllegalStateException(e, err);
         goto init_failed;
     }
@@ -703,8 +703,8 @@ WF_OPENSSL(jboolean, setCipherSuites)(JNIEnv *e, jobject o, jlong ssl, jstring c
         return JNI_FALSE;
     }
     if (!ssl_methods.SSL_set_cipher_list(ssl_, J2S(ciphers))) {
-        char err[256];
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        char err[2048];
+        generate_openssl_stack_error(e, err, sizeof(err));
         throwIllegalStateException(e, err);
         rv = JNI_FALSE;
     }
@@ -833,8 +833,8 @@ WF_OPENSSL(jboolean, setCipherSuite)(JNIEnv *e, jobject o, jlong ctx, jstring ci
 #else
     if (!ssl_methods.SSL_CTX_set_cipher_list(c->ctx, J2S(ciphers))) {
 #endif
-        char err[256];
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        char err[2048];
+        generate_openssl_stack_error(e, err, sizeof(err));
         tcn_Throw(e, "Unable to configure permitted SSL ciphers (%s)", err);
         rv = JNI_FALSE;
     }
@@ -867,8 +867,8 @@ jstring hostName)
     }
     if (!ssl_methods.SSL_ctrl(ssl_, SSL_CTRL_SET_TLSEXT_HOSTNAME,
         TLSEXT_NAMETYPE_host_name, (void *)hostNameString)) {
-        char err[256];
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        char err[2048];
+        generate_openssl_stack_error(e, err, sizeof(err));
         throwIllegalStateException(e, err);
         rv = JNI_FALSE;
     }
@@ -884,7 +884,7 @@ WF_OPENSSL(jboolean, setCARevocation)(JNIEnv *e, jobject o, jlong ctx, jstring f
     TCN_ALLOC_CSTRING(path);
     jboolean rv = JNI_FALSE;
     X509_LOOKUP *lookup;
-    char err[256];
+    char err[2048];
 
     UNREFERENCED(o);
     TCN_ASSERT(ctx != 0);
@@ -898,7 +898,7 @@ WF_OPENSSL(jboolean, setCARevocation)(JNIEnv *e, jobject o, jlong ctx, jstring f
     if (J2S(file)) {
         lookup = crypto_methods.X509_STORE_add_lookup(c->crl, crypto_methods.X509_LOOKUP_file());
         if (lookup == NULL) {
-            crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+            generate_openssl_stack_error(e, err, sizeof(err));
             crypto_methods.X509_STORE_free(c->crl);
             c->crl = NULL;
             tcn_Throw(e, "Lookup failed for file %s (%s)", J2S(file), err);
@@ -909,7 +909,7 @@ WF_OPENSSL(jboolean, setCARevocation)(JNIEnv *e, jobject o, jlong ctx, jstring f
     if (J2S(path)) {
         lookup = crypto_methods.X509_STORE_add_lookup(c->crl, crypto_methods.X509_LOOKUP_hash_dir());
         if (lookup == NULL) {
-            crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+            generate_openssl_stack_error(e, err, sizeof(err));
             crypto_methods.X509_STORE_free(c->crl);
             c->crl = NULL;
             tcn_Throw(e, "Lookup failed for path %s (%s)", J2S(file), err);
@@ -930,7 +930,7 @@ WF_OPENSSL(jboolean, setCertificate)(JNIEnv *e, jobject o, jlong ctx, jbyteArray
     /* we get the key contents into a byte array */
     unsigned char* cert;
     unsigned char* intCert;
-    char err[256];
+    char err[2048];
     jboolean rv;
     const unsigned char *tmp;
     jsize lengthOfCert;
@@ -967,7 +967,7 @@ WF_OPENSSL(jboolean, setCertificate)(JNIEnv *e, jobject o, jlong ctx, jbyteArray
     }
     tmp = (const unsigned char *)cert;
     if ((c->certs[idx] = crypto_methods.d2i_X509(NULL, &tmp, lengthOfCert)) == NULL) {
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        generate_openssl_stack_error(e, err, sizeof(err));
         throwIllegalStateException(e, err);
         rv = JNI_FALSE;
         goto cleanup;
@@ -983,14 +983,14 @@ WF_OPENSSL(jboolean, setCertificate)(JNIEnv *e, jobject o, jlong ctx, jbyteArray
     c->keys[idx] = crypto_methods.PEM_read_bio_PrivateKey(bio, NULL, 0, NULL);
     crypto_methods.BIO_free(bio);
     if (c->keys[idx] == NULL) {
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        generate_openssl_stack_error(e, err, sizeof(err));
         throwIllegalStateException(e, err);
         rv = JNI_FALSE;
         goto cleanup;
     }
 
     if (ssl_methods.SSL_CTX_use_certificate(c->ctx, c->certs[idx]) <= 0) {
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        generate_openssl_stack_error(e, err, sizeof(err));
         tcn_Throw(e, "Error setting certificate (%s)", err);
         rv = JNI_FALSE;
         goto cleanup;
@@ -1011,7 +1011,7 @@ WF_OPENSSL(jboolean, setCertificate)(JNIEnv *e, jobject o, jlong ctx, jbyteArray
 
 
         if ((tmpIntCert = crypto_methods.d2i_X509(NULL, &tmp, lengthOfCert)) == NULL) {
-            crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+            generate_openssl_stack_error(e, err, sizeof(err));
             throwIllegalStateException(e, err);
             rv = JNI_FALSE;
             free(intCert);
@@ -1019,7 +1019,7 @@ WF_OPENSSL(jboolean, setCertificate)(JNIEnv *e, jobject o, jlong ctx, jbyteArray
         }
 
         if (ssl_methods.SSL_CTX_ctrl(c->ctx,SSL_CTRL_EXTRA_CHAIN_CERT,0,(char *)tmpIntCert) <= 0) {
-            crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+            generate_openssl_stack_error(e, err, sizeof(err));
             tcn_Throw(e, "Error setting certificate (%s)", err);
             rv = JNI_FALSE;
             free(intCert);
@@ -1030,13 +1030,13 @@ WF_OPENSSL(jboolean, setCertificate)(JNIEnv *e, jobject o, jlong ctx, jbyteArray
 
 
     if (ssl_methods.SSL_CTX_use_PrivateKey(c->ctx, c->keys[idx]) <= 0) {
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        generate_openssl_stack_error(e, err, sizeof(err));
         tcn_Throw(e, "Error setting private key (%s)", err);
         rv = JNI_FALSE;
         goto cleanup;
     }
     if (ssl_methods.SSL_CTX_check_private_key(c->ctx) <= 0) {
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        generate_openssl_stack_error(e, err, sizeof(err));
         tcn_Throw(e, "Private key does not match the certificate public key (%s)",
                   err);
         rv = JNI_FALSE;
@@ -1437,7 +1437,7 @@ WF_OPENSSL(void, freeBIO)(JNIEnv *e, jobject o, jlong bio /* BIO * */) {
 WF_OPENSSL(jstring, getErrorString)(JNIEnv *e, jobject o, jlong number)
 {
 #pragma comment(linker, "/EXPORT:"__FUNCTION__"="__FUNCDNAME__)
-    char buf[256];
+    char buf[2048];
     UNREFERENCED(o);
     crypto_methods.ERR_error_string(number, buf);
     return tcn_new_string(e, buf);
@@ -1604,8 +1604,8 @@ static unsigned char dhparams[]={
     0x2D, 0x2D, 0x2D, 0x2D, 0x2D, };
     bio = crypto_methods.BIO_new(crypto_methods.BIO_s_mem());
     if (!bio) {
-        char err[256];
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        char err[2048];
+        generate_openssl_stack_error(e, err, sizeof(err));
         tcn_Throw(e, "Error while configuring DH %s", err);
         return;
     }
@@ -1614,16 +1614,16 @@ static unsigned char dhparams[]={
     dh = crypto_methods.PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
     crypto_methods.BIO_free(bio);
     if (!dh) {
-        char err[256];
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        char err[2048];
+        generate_openssl_stack_error(e, err, sizeof(err));
         tcn_Throw(e, "Error while configuring DH: no DH parameter found (%s)", err);
         return;
     }
 
     if (1 != ssl_methods.SSL_CTX_ctrl(ctx,SSL_CTRL_SET_TMP_DH,0,(char *)dh)) {
-        char err[256];
+        char err[2048];
         crypto_methods.DH_free(dh);
-        crypto_methods.ERR_error_string(crypto_methods.ERR_get_error(), err);
+        generate_openssl_stack_error(e, err, sizeof(err));
         tcn_Throw(e, "Error while configuring DH: %s", err);
     }
 


### PR DESCRIPTION
The main problem was that the method `tcn_Throw` just didn't include the real openssl message (so the %s was not filled with the real issue). I have used the standard `vsnprintf` with a 4096 buffer.

The other problem was that only the first openssl was retrieved instead the full stack. I decided to include the `ERR_print_errors` openssl method to dump all the stack into a buffer.

Because the messages can be longer now all the buffers have been increased from 256 to 2048.

Besides I have removed the include of the `opensslv.h` because the version checking should be done at runtime (never at compilation time). This was a mistake and complicates the compilation in windows.

If you prefer to allocate the buffers just let me know but I thought it was easier to respect original idea. The same if you prefer a different size.