### PR TITLE
[WFSSL-31] Add the ability to make use of the 'jboss.modules.os-name' property when building on RHEL platforms

### DIFF
--- a/el6-i386/Makefile
+++ b/el6-i386/Makefile
@@ -1,0 +1,17 @@
+CC = cc
+SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
+OBJ = $(patsubst %.c, target/%.o, $(SRC))
+
+default: target/classes/el6-i386/libwfssl.so
+
+clean:
+	rm -rf target
+
+target/classes/el6-i386:
+	mkdir -p target/classes/el6-i386
+
+target/%.o : ../libwfssl/src/%.c target/classes/el6-i386
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -m32 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+
+target/classes/el6-i386/libwfssl.so: $(OBJ)
+	$(CC) $(CFLAGS) -m32 -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl

--- a/el6-i386/pom.xml
+++ b/el6-i386/pom.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.openssl</groupId>
+        <artifactId>wildfly-openssl-parent</artifactId>
+        <version>1.0.11.Final-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.openssl</groupId>
+    <artifactId>wildfly-openssl-el6-i386</artifactId>
+    <version>1.0.11.Final-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>make</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>parent-release</id>
+            <activation>
+                <property>
+                    <name>parent-release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/el6-x86_64/Makefile
+++ b/el6-x86_64/Makefile
@@ -1,0 +1,17 @@
+CC = cc
+SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
+OBJ = $(patsubst %.c, target/%.o, $(SRC))
+
+default: target/classes/el6-x86_64/libwfssl.so
+
+clean:
+	rm -rf target
+
+target/classes/el6-x86_64:
+	mkdir -p target/classes/el6-x86_64
+
+target/%.o : ../libwfssl/src/%.c target/classes/el6-x86_64
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+
+target/classes/el6-x86_64/libwfssl.so: $(OBJ)
+	$(CC) $(CFLAGS) -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl

--- a/el6-x86_64/pom.xml
+++ b/el6-x86_64/pom.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.openssl</groupId>
+        <artifactId>wildfly-openssl-parent</artifactId>
+        <version>1.0.11.Final-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.openssl</groupId>
+    <artifactId>wildfly-openssl-el6-x86_64</artifactId>
+    <version>1.0.11.Final-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>make</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>parent-release</id>
+            <activation>
+                <property>
+                    <name>parent-release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/el7-x86_64/Makefile
+++ b/el7-x86_64/Makefile
@@ -1,0 +1,17 @@
+CC = cc
+SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
+OBJ = $(patsubst %.c, target/%.o, $(SRC))
+
+default: target/classes/el7-x86_64/libwfssl.so
+
+clean:
+	rm -rf target
+
+target/classes/el7-x86_64:
+	mkdir -p target/classes/el7-x86_64
+
+target/%.o : ../libwfssl/src/%.c target/classes/el7-x86_64
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+
+target/classes/el7-x86_64/libwfssl.so: $(OBJ)
+	$(CC) $(CFLAGS) -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl

--- a/el7-x86_64/pom.xml
+++ b/el7-x86_64/pom.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.openssl</groupId>
+        <artifactId>wildfly-openssl-parent</artifactId>
+        <version>1.0.11.Final-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.openssl</groupId>
+    <artifactId>wildfly-openssl-el7-x86_64</artifactId>
+    <version>1.0.11.Final-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>make</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>parent-release</id>
+            <activation>
+                <property>
+                    <name>parent-release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/el8-x86_64/Makefile
+++ b/el8-x86_64/Makefile
@@ -1,0 +1,17 @@
+CC = cc
+SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
+OBJ = $(patsubst %.c, target/%.o, $(SRC))
+
+default: target/classes/el8-x86_64/libwfssl.so
+
+clean:
+	rm -rf target
+
+target/classes/el8-x86_64:
+	mkdir -p target/classes/el8-x86_64
+
+target/%.o : ../libwfssl/src/%.c target/classes/el8-x86_64
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+
+target/classes/el8-x86_64/libwfssl.so: $(OBJ)
+	$(CC) $(CFLAGS) -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl

--- a/el8-x86_64/pom.xml
+++ b/el8-x86_64/pom.xml
@@ -1,0 +1,82 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.openssl</groupId>
+        <artifactId>wildfly-openssl-parent</artifactId>
+        <version>1.0.11.Final-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.openssl</groupId>
+    <artifactId>wildfly-openssl-el8-x86_64</artifactId>
+    <version>1.0.11.Final-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>make</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>parent-release</id>
+            <activation>
+                <property>
+                    <name>parent-release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -294,6 +294,46 @@
             </dependencies>
         </profile>
         <profile>
+            <id>custom-x86_64</id>
+            <activation>
+                <property>
+                    <name>jboss.modules.os-name</name>
+                </property>
+                <os>
+                    <family>linux</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.openssl</groupId>
+                    <artifactId>wildfly-openssl-${jboss.modules.os-name}-x86_64</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>custom-i386</id>
+            <activation>
+                <property>
+                    <name>jboss.modules.os-name</name>
+                </property>
+                <os>
+                    <family>linux</family>
+                    <arch>i386</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.openssl</groupId>
+                    <artifactId>wildfly-openssl-${jboss.modules.os-name}-i386</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>release</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -244,5 +244,35 @@
                 <module>windows-i386</module>
             </modules>
         </profile>
+        <profile>
+            <id>custom-x86_64</id>
+            <activation>
+                <property>
+                    <name>jboss.modules.os-name</name>
+                </property>
+                <os>
+                    <family>linux</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <modules>
+                <module>${jboss.modules.os-name}-x86_64</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>custom-i386</id>
+            <activation>
+                <property>
+                    <name>jboss.modules.os-name</name>
+                </property>
+                <os>
+                    <family>linux</family>
+                    <arch>i386</arch>
+                </os>
+            </activation>
+            <modules>
+                <module>${jboss.modules.os-name}-i386</module>
+            </modules>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This PR adds two new custom profiles for Linux `x86_64` and `i386` architectures that build the `${jboss.modules.os-name}-{x86_64|i386}` module. When building on different RHEL platforms, the following commands can now be used:

- RHEL 6: `mvn clean install -Djboss.modules.os-name=el6`
- RHEL 7: `mvn clean install -Djboss.modules.os-name=el7`
- RHEL 8: `mvn clean install -Djboss.modules.os-name=el8`

As an example, for the `x86_64` architecture, running `mvn clean install -Djboss.modules.os-name=el7` will result in a `wildfly-openssl-el7-x86_64` artifact in the `el7-x86_64` directory.

The same `jboss.modules.os-name` property would also need to be specified at runtime on RHEL platforms to make sure the right natives get loaded.

For the rest of the platforms, the build process is unchanged.

For more details on this PR, see the description in [WFSSL-31](https://issues.redhat.com/browse/WFSSL-31).