### PR TITLE
[WFSSL-16] Add support for TLS 1.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,11 +74,44 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
+                <version>3.8.0-jboss-2</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>8</release>
+                            <buildDirectory>${project.build.directory}</buildDirectory>
+                            <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.directory}/jdk-misc.jar</additionalClasspathElement>
+                            </additionalClasspathElements>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>fetch-misc</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>get</goal>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifact>org.jboss:jdk-misc:2.Final</artifact>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <stripVersion>true</stripVersion>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/java/src/main/java/org/wildfly/openssl/Messages.java
+++ b/java/src/main/java/org/wildfly/openssl/Messages.java
@@ -69,6 +69,10 @@ public class Messages {
     private static final String MSG37 = formatCode(37);
     private static final String MSG38 = formatCode(38);
     private static final String MSG39 = formatCode(39);
+    private static final String MSG40 = formatCode(40);
+    private static final String MSG41 = formatCode(41);
+    private static final String MSG42 = formatCode(42);
+    private static final String MSG43 = formatCode(43);
 
     private static String formatCode(int i) {
         return CODE + new DecimalFormat("0000").format(i);
@@ -222,5 +226,13 @@ public class Messages {
     public String unsupportedProtocolVersion(int p) {
         return interpolate(MSG39, p);
     }
-
+    public String handshakeFailed() {
+        return interpolate(MSG41);
+    }
+    public String settingCipherSuites(String s) {
+        return interpolate(MSG42, s);
+    }
+    public String settingTls13CipherSuites(String s) {
+        return interpolate(MSG43, s);
+    }
 }

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLContextSPI.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLContextSPI.java
@@ -18,6 +18,8 @@
 package org.wildfly.openssl;
 
 
+import static org.wildfly.openssl.OpenSSLEngine.isTLS13Supported;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
@@ -71,6 +73,8 @@ public abstract class OpenSSLContextSPI extends SSLContextSpi {
 
     private static volatile String[] allAvailableCiphers;
 
+    private static final String TLS13_CIPHERS = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_AES_128_CCM_SHA256:TLS_AES_128_CCM_8_SHA256";
+
     protected final long ctx;
     final int supportedCiphers;
 
@@ -94,10 +98,14 @@ public abstract class OpenSSLContextSPI extends SSLContextSpi {
                 if(allAvailableCiphers == null) {
 
                     final Set<String> availableCipherSuites = new LinkedHashSet<>(128);
+                    boolean tls13Supported = isTLS13Supported();
                     try {
                         final long sslCtx = SSL.getInstance().makeSSLContext(SSL.SSL_PROTOCOL_ALL, SSL.SSL_MODE_SERVER);
                         try {
                             SSL.getInstance().setSSLContextOptions(sslCtx, SSL.SSL_OP_ALL);
+                            if (tls13Supported) {
+                                SSL.getInstance().setCipherSuiteTLS13(sslCtx, TLS13_CIPHERS);
+                            }
                             SSL.getInstance().setCipherSuite(sslCtx, "ALL");
                             final long ssl = SSL.getInstance().newSSL(sslCtx, true);
                             try {
@@ -482,6 +490,13 @@ public abstract class OpenSSLContextSPI extends SSLContextSpi {
 
         public OpenSSLTLS_1_2_ContextSpi() throws SSLException {
             super(SSL.SSL_PROTOCOL_TLSV1_2);
+        }
+    }
+
+    public static final class OpenSSLTLS_1_3_ContextSpi extends OpenSSLContextSPI {
+
+        public OpenSSLTLS_1_3_ContextSpi() throws SSLException {
+            super(SSL.SSL_PROTOCOL_TLSV1_3);
         }
     }
 }

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLProvider.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLProvider.java
@@ -27,6 +27,13 @@ public final class OpenSSLProvider extends Provider {
 
     private static boolean registered = false;
 
+    private static final String javaSpecVersion = System.getProperty("java.specification.version");
+
+    static int getJavaSpecVersion() {
+        if ("1.8".equals(javaSpecVersion)) return 8;
+        return Integer.parseInt(javaSpecVersion);
+    }
+
     public static final OpenSSLProvider INSTANCE = new OpenSSLProvider();
 
     public OpenSSLProvider() {
@@ -35,10 +42,16 @@ public final class OpenSSLProvider extends Provider {
         put("SSLContext.openssl.TLSv1", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLS_1_0_ContextSpi.class.getSimpleName());
         put("SSLContext.openssl.TLSv1.1", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLS_1_1_ContextSpi.class.getSimpleName());
         put("SSLContext.openssl.TLSv1.2", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLS_1_2_ContextSpi.class.getSimpleName());
+        if (getJavaSpecVersion() >= 11) {
+            put("SSLContext.openssl.TLSv1.3", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLS_1_3_ContextSpi.class.getSimpleName());
+        }
         put("SSLContext.TLS", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLSContextSpi.class.getSimpleName());
         put("SSLContext.TLSv1", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLS_1_0_ContextSpi.class.getSimpleName());
         put("SSLContext.TLSv1.1", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLS_1_1_ContextSpi.class.getSimpleName());
         put("SSLContext.TLSv1.2", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLS_1_2_ContextSpi.class.getSimpleName());
+        if (getJavaSpecVersion() >= 11) {
+            put("SSLContext.TLSv1.3", OpenSSLContextSPI.class.getName() + "$" + OpenSSLContextSPI.OpenSSLTLS_1_3_ContextSpi.class.getSimpleName());
+        }
     }
 
     public static synchronized void register() {

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLServerSessionContext.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLServerSessionContext.java
@@ -25,9 +25,7 @@ public final class OpenSSLServerSessionContext extends OpenSSLSessionContext {
 
     OpenSSLServerSessionContext(long context) {
         super(context);
-        SSL.getInstance().registerSessionContext(context, this);
     }
-
 
     @Override
     public void setSessionTimeout(int seconds) {

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
@@ -31,6 +31,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.net.ssl.HandshakeCompletedEvent;
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.SSLEngineResult;
@@ -43,6 +46,8 @@ import javax.net.ssl.SSLSocket;
  * @author Stuart Douglas
  */
 public class OpenSSLSocket extends SSLSocket {
+
+    private static final Logger logger = Logger.getLogger(OpenSSLSocket.class.getName());
 
     private final OpenSSLEngine sslEngine;
     private final List<HandshakeCompletedListener> handshakeCompletedListenerList = new ArrayList<>();
@@ -190,7 +195,16 @@ public class OpenSSLSocket extends SSLSocket {
 
     @Override
     public SSLSession getSession() {
-        return sslEngine.getSession();
+        if (sslEngine.isHandshakeFinished() || sslEngine.isOutboundDone() || sslEngine.isInboundDone()) {
+            return sslEngine.getSession();
+        } else {
+            try {
+                startHandshake();
+            } catch (IOException e) {
+                logger.log(Level.WARNING, Messages.MESSAGES.handshakeFailed(), e);
+            }
+            return sslEngine.getSession();
+        }
     }
 
     @Override

--- a/java/src/main/java/org/wildfly/openssl/SSL.java
+++ b/java/src/main/java/org/wildfly/openssl/SSL.java
@@ -296,6 +296,7 @@ public abstract class SSL {
      */
     static final String SSL_PROTO_ALL = "all";
     static final String SSL_PROTO_TLS = "TLS";
+    static final String SSL_PROTO_TLSv1_3 = "TLSv1.3";
     static final String SSL_PROTO_TLSv1_2 = "TLSv1.2";
     static final String SSL_PROTO_TLSv1_1 = "TLSv1.1";
     static final String SSL_PROTO_TLSv1 = "TLSv1";
@@ -354,7 +355,8 @@ public abstract class SSL {
     static final int SSL_PROTOCOL_TLSV1 = (1 << 2);
     static final int SSL_PROTOCOL_TLSV1_1 = (1 << 3);
     static final int SSL_PROTOCOL_TLSV1_2 = (1 << 4);
-    static final int SSL_PROTOCOL_ALL = (SSL_PROTOCOL_TLSV1 | SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2);
+    static final int SSL_PROTOCOL_TLSV1_3 = (1 << 5);
+    static final int SSL_PROTOCOL_ALL = (SSL_PROTOCOL_TLSV1 | SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2 | SSL_PROTOCOL_TLSV1_3);
 
     /*
      * Define the SSL verify levels
@@ -419,6 +421,7 @@ public abstract class SSL {
     static final int SSL_OP_NO_SSLv2 = 0x01000000;
     static final int SSL_OP_NO_SSLv3 = 0x02000000;
     static final int SSL_OP_NO_TLSv1 = 0x04000000;
+    static final int SSL_OP_NO_TLSv1_3 = 0x20000000;
     static final int SSL_OP_NO_TLSv1_2 = 0x08000000;
     static final int SSL_OP_NO_TLSv1_1 = 0x10000000;
 
@@ -426,6 +429,7 @@ public abstract class SSL {
     static final int TLS1_VERSION = 0x0301;
     static final int TLS1_1_VERSION = 0x0302;
     static final int TLS1_2_VERSION = 0x0303;
+    static final int TLS1_3_VERSION = 0x0304;
 
     static final int SSL_OP_NO_TICKET = 0x00004000;
 
@@ -514,8 +518,8 @@ public abstract class SSL {
      */
     static final int SSL_INFO_CLIENT_CERT_CHAIN = 0x0400;
 
-    /* Only support OFF and SERVER for now */
     static final long SSL_SESS_CACHE_OFF = 0x0000;
+    static final long SSL_SESS_CACHE_CLIENT = 0x0001;
     static final long SSL_SESS_CACHE_SERVER = 0x0002;
 
     static final int SSL_SELECTOR_FAILURE_NO_ADVERTISE = 0;
@@ -523,6 +527,7 @@ public abstract class SSL {
 
     static final long VERSION_1_1_0 = 0x10100000L;
     static final long VERSION_1_1_0_F = 0x1010006fL;
+    static final long VERSION_1_1_1 = 0x10101000L;
 
     /* Return OpenSSL version number */
     protected abstract String version();
@@ -824,6 +829,17 @@ public abstract class SSL {
     protected abstract boolean setCipherSuites(long ssl, String ciphers)
             throws Exception;
 
+    /**
+     * Sets the cipher suites available for negotiation in the SSL handshake.
+     * <br />
+     * This is a simple colon (":") separated list of TLSv1.3 ciphersuite names in order of preference.
+     *
+     * @param ssl     the SSL instance (SSL *)
+     * @param ciphers an SSL cipher specification
+     */
+    protected abstract boolean setCipherSuitesTLS13(long ssl, String ciphers)
+            throws Exception;
+
     protected abstract boolean setServerNameIndication(long ssl,
                                                        String hostName);
 
@@ -879,6 +895,7 @@ public abstract class SSL {
      *                 {@link SSL#SSL_PROTOCOL_TLSV1}
      *                 {@link SSL#SSL_PROTOCOL_TLSV1_1}
      *                 {@link SSL#SSL_PROTOCOL_TLSV1_2}
+     *                 {@link SSL#SSL_PROTOCOL_TLSV1_3}
      *                 {@link SSL#SSL_PROTOCOL_ALL} ( == all TLS versions, no SSL)
      *                 </PRE>
      * @param mode     SSL mode to use
@@ -949,6 +966,17 @@ public abstract class SSL {
      * @param ciphers An SSL cipher specification.
      */
     protected abstract boolean setCipherSuite(long ctx, String ciphers)
+            throws Exception;
+
+    /**
+     * Sets the cipher suites available for negotiation in the SSL handshake.
+     * <br />
+     * This is a simple colon (":") separated list of TLSv1.3 ciphersuite names in order of preference.
+     *
+     * @param ctx     Server or Client context to use.
+     * @param ciphers an SSL cipher specification
+     */
+    protected abstract boolean setCipherSuiteTLS13(long ctx, String ciphers)
             throws Exception;
 
     /**
@@ -1133,7 +1161,7 @@ public abstract class SSL {
      */
     protected abstract void invalidateSession(long ctx);
 
-    protected abstract void registerSessionContext(long context, OpenSSLServerSessionContext openSSLServerSessionContext);
+    protected abstract void registerSessionContext(long context, OpenSSLSessionContext openSSLSessionContext);
 
     /**
      * Interface implemented by components that will receive the call back to
@@ -1228,6 +1256,14 @@ public abstract class SSL {
      * @return the maximum supported protocol version
      */
     protected abstract int getMaxProtoVersion(long ssl);
+
+    /**
+     * Return whether or not the SSL session was reused.
+     * See https://www.openssl.org/docs/man1.1.1/man3/SSL_session_reused.html
+     * @param ssl the SSL engine
+     * @return {@code true} if the SSL session was reused and {@code false} otherwise
+     */
+    protected abstract boolean getSSLSessionReused(long ssl);
 
     private static final class VersionedLibrary implements Comparable<VersionedLibrary> {
         final String file;

--- a/java/src/main/java/org/wildfly/openssl/SSLImpl.java
+++ b/java/src/main/java/org/wildfly/openssl/SSLImpl.java
@@ -436,6 +436,11 @@ public class SSLImpl extends SSL {
         return setCipherSuites0(ssl, ciphers);
     }
 
+    @Override
+    protected boolean setCipherSuitesTLS13(long ssl, String ciphers) throws Exception {
+        return setCipherSuitesTLS130(ssl, ciphers);
+    }
+
     static native boolean setServerNameIndication0(long ssl, String hostName);
 
     @Override
@@ -481,6 +486,16 @@ public class SSLImpl extends SSL {
      */
     static native boolean setCipherSuites0(long ssl, String ciphers) throws Exception;
 
+    /**
+     * Sets the cipher suites available for negotiation in the SSL handshake.
+     * <br />
+     * This is a simple colon (":") separated list of TLSv1.3 ciphersuite names in order of preference.
+     *
+     * @param ssl     the SSL instance (SSL *)
+     * @param ciphers an SSL cipher specification
+     */
+    static native boolean setCipherSuitesTLS130(long ssl, String ciphers) throws Exception;
+
 
     /**
      * Returns the ID of the session as byte array representation.
@@ -517,6 +532,7 @@ public class SSLImpl extends SSL {
      *                 {@link SSLImpl#SSL_PROTOCOL_TLSV1}
      *                 {@link SSLImpl#SSL_PROTOCOL_TLSV1_1}
      *                 {@link SSLImpl#SSL_PROTOCOL_TLSV1_2}
+     *                 {@link SSLImpl#SSL_PROTOCOL_TLSV1_3}
      *                 {@link SSLImpl#SSL_PROTOCOL_ALL} ( == all TLS versions, no SSL)
      *                 </PRE>
      * @param mode     SSL mode to use
@@ -597,6 +613,11 @@ public class SSLImpl extends SSL {
     }
 
     @Override
+    protected boolean setCipherSuiteTLS13(long ctx, String ciphers) throws Exception {
+        return setCipherSuiteTLS130(ctx, ciphers);
+    }
+
+    @Override
     protected boolean setCARevocation(long ctx, String file, String path) throws Exception {
         return setCARevocation0(ctx, file, path);
     }
@@ -622,6 +643,16 @@ public class SSLImpl extends SSL {
      * @param ciphers An SSL cipher specification.
      */
     static native boolean setCipherSuite0(long ctx, String ciphers) throws Exception;
+
+    /**
+     * Sets the cipher suites available for negotiation in the SSL handshake.
+     * <br />
+     * This is a simple colon (":") separated list of TLSv1.3 ciphersuite names in order of preference.
+     *
+     * @param ctx     Server or Client context to use.
+     * @param ciphers an SSL cipher specification
+     */
+    static native boolean setCipherSuiteTLS130(long ctx, String ciphers) throws Exception;
 
     /**
      * Set File of concatenated PEM-encoded CA CRLs or
@@ -823,10 +854,10 @@ public class SSLImpl extends SSL {
         SSLImpl.invalidateSession0(ctx);
     }
 
-    static native void registerSessionContext0(long context, OpenSSLServerSessionContext openSSLServerSessionContext);
+    static native void registerSessionContext0(long context, OpenSSLSessionContext openSSLSessionContext);
 
-    protected void registerSessionContext(long context, OpenSSLServerSessionContext openSSLServerSessionContext) {
-        SSLImpl.registerSessionContext0(context, openSSLServerSessionContext);
+    protected void registerSessionContext(long context, OpenSSLSessionContext openSSLSessionContext) {
+        SSLImpl.registerSessionContext0(context, openSSLSessionContext);
     }
 
     /**
@@ -907,4 +938,11 @@ public class SSLImpl extends SSL {
     protected int getMaxProtoVersion(long ssl) {
         return SSLImpl.getMaxProtoVersion0(ssl);
     }
+
+    static native boolean getSSLSessionReused0(long ssl);
+
+    protected boolean getSSLSessionReused(long ssl) {
+        return SSLImpl.getSSLSessionReused0(ssl);
+    }
+
 }

--- a/java/src/main/resources/org/wildfly/openssl/OpenSSLMessages.properties
+++ b/java/src/main/resources/org/wildfly/openssl/OpenSSLMessages.properties
@@ -55,3 +55,6 @@ WFOPENSSL0037=Failed to initialize DirectByteBufferDeallocator
 WFOPENSSL0038=Failed to free direct buffer
 WFOPENSSL0039=Unsupported protocol version %d
 WFOPENSSL0040=The protocol versions returned by the org.wildfly.openssl.OpenSSLEngine.getEnabledProtocols() method may not be accurate when using an OpenSSL version between 1.1.0 and 1.1.0f. This method will return the correct value when using OpenSSL 1.1.0g or higher.
+WFOPENSSL0041=Handshake failed
+WFOPENSSL0042=Setting pre-TLS 1.3 cipher suites to %s
+WFOPENSSL0043=Setting TLS 1.3 cipher suites to %s

--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineTest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineTest.java
@@ -17,21 +17,34 @@
 
 package org.wildfly.openssl;
 
+import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL10;
+import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL110FOrLower;
+import static org.wildfly.openssl.OpenSSLEngine.isTLS13Supported;
+import static org.wildfly.openssl.OpenSSLProvider.getJavaSpecVersion;
 import static org.wildfly.openssl.SSL.SSL_PROTO_SSLv2Hello;
+import static org.wildfly.openssl.SSLTestUtils.HOST;
+import static org.wildfly.openssl.SSLTestUtils.PORT;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 /**
@@ -40,29 +53,62 @@ import org.junit.Test;
 public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
 
     public static final String MESSAGE = "Hello World";
-    private static final String javaSpecVersion = System.getProperty("java.specification.version");
-
-    static int getJavaSpecVersion() {
-        if ("1.8".equals(javaSpecVersion)) return 8;
-        return Integer.parseInt(javaSpecVersion);
-    }
 
     @Test
     public void basicOpenSSLTest() throws IOException, NoSuchAlgorithmException, InterruptedException {
+        final String[] providers = new String[] { "openssl.TLSv1", "openssl.TLSv1.1", "openssl.TLSv1.2" };
+        for (String provider : providers) {
+            basicTest(provider, provider);
+        }
+    }
+
+    @Test
+    public void basicOpenSSLTestTLS13() throws IOException, NoSuchAlgorithmException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        basicTest("openssl.TLSv1.3", "openssl.TLSv1.3");
+    }
+
+    @Test
+    public void basicOpenSSLTestInterop() throws IOException, NoSuchAlgorithmException, InterruptedException {
+        final String[] providers = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+        for (String provider : providers) {
+            basicTest("openssl." + provider, provider);
+        }
+        for (String provider : providers) {
+            basicTest(provider, "openssl." + provider);
+        }
+    }
+
+    @Test
+    public void basicOpenSSLTestInteropTLS13() throws IOException, NoSuchAlgorithmException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        basicTest("openssl.TLSv1.3", "TLSv1.3");
+        basicTest("TLSv1.3", "openssl.TLSv1.3");
+    }
+
+    private void basicTest(String serverProvider, String clientProvider) throws IOException, InterruptedException {
         try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
-            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1");
+            final SSLContext sslContext = SSLTestUtils.createSSLContext(serverProvider);
 
             Thread acceptThread = new Thread(new EchoRunnable(serverSocket, sslContext, sessionID));
             acceptThread.start();
-            final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            final SSLSocket socket = (SSLSocket) SSLTestUtils.createClientSSLContext(clientProvider).getSocketFactory().createSocket();
+            socket.setReuseAddress(true);
             socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
             byte[] data = new byte[100];
             int read = socket.getInputStream().read(data);
 
             Assert.assertEquals(MESSAGE, new String(data, 0, read));
-            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+            if (! isTLS13Supported()) {
+                Assert.assertNotNull(socket.getSession().getId());
+                if (sessionID.get() != null) {
+                    // may be null with some older versions of OpenSSL (this assertion is also commented
+                    // out in other existing tests)
+                    Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+                }
+            }
             socket.getSession().invalidate();
             socket.close();
             serverSocket.close();
@@ -88,14 +134,24 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
             Thread acceptThread = new Thread(echo);
             acceptThread.start();
             final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
             socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
             byte[] data = new byte[100];
             int read = socket.getInputStream().read(data);
+            SSLEngine sslEngine = engineRef.get();
+            SSLSession session = sslEngine.getSession();
 
             Assert.assertEquals(MESSAGE, new String(data, 0, read));
-            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
-            Assert.assertEquals("TLSv1.2", socket.getSession().getProtocol());
+            if (! isTLS13Supported()) {
+                Assert.assertArrayEquals(sessionID.get(), socket.getSession().getId());
+                Assert.assertEquals("TLSv1.2", socket.getSession().getProtocol());
+                Assert.assertArrayEquals(sessionID.get(), session.getId());
+                Assert.assertFalse(CipherSuiteConverter.isTLSv13CipherSuite(socket.getSession().getCipherSuite()));
+            } else {
+                Assert.assertEquals("TLSv1.3", socket.getSession().getProtocol());
+                Assert.assertTrue(CipherSuiteConverter.isTLSv13CipherSuite(socket.getSession().getCipherSuite()));
+            }
             socket.getSession().invalidate();
             socket.close();
             serverSocket.close();
@@ -107,37 +163,121 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
     public void testSingleEnabledProtocol() throws IOException, InterruptedException {
         final String[] protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
         for (String protocol : protocols) {
-            try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
-                final AtomicReference<byte[]> sessionID = new AtomicReference<>();
-                final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
-                final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
+            testSingleEnabledProtocolBase(protocol);
+        }
+    }
 
-                EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
-                    engineRef.set(engine);
-                    try {
-                        engine.setEnabledProtocols(new String[]{ protocol }); // only one protocol enabled on server side
-                        return engine;
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }));
-                Thread acceptThread = new Thread(echo);
-                acceptThread.start();
-                final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-                socket.connect(SSLTestUtils.createSocketAddress());
-                socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
-                byte[] data = new byte[100];
-                int read = socket.getInputStream().read(data);
+    @Test
+    public void testSingleEnabledProtocolTLS13() throws IOException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        testSingleEnabledProtocolBase("TLSv1.3");
+    }
 
-                Assert.assertEquals(MESSAGE, new String(data, 0, read));
+    private void testSingleEnabledProtocolBase(String protocol) throws IOException, InterruptedException {
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
+            final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
+
+            EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
+                engineRef.set(engine);
+                try {
+                    engine.setEnabledProtocols(new String[]{ protocol }); // only one protocol enabled on server side
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Thread acceptThread = new Thread(echo);
+            acceptThread.start();
+            final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
+            socket.connect(SSLTestUtils.createSocketAddress());
+            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+            byte[] data = new byte[100];
+            int read = socket.getInputStream().read(data);
+
+            Assert.assertEquals(MESSAGE, new String(data, 0, read));
+            if (! protocol.equals("TLSv1.3")) {
                 Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
-                Assert.assertEquals(protocol, socket.getSession().getProtocol());
-                Assert.assertArrayEquals(new String[]{ SSL_PROTO_SSLv2Hello, protocol }, engineRef.get().getEnabledProtocols());
-                socket.getSession().invalidate();
-                socket.close();
-                serverSocket.close();
-                acceptThread.join();
             }
+            Assert.assertEquals(protocol, socket.getSession().getProtocol());
+            Assert.assertEquals(protocol.equals("TLSv1.3"), CipherSuiteConverter.isTLSv13CipherSuite(socket.getSession().getCipherSuite()));
+            Assert.assertArrayEquals(new String[]{ SSL_PROTO_SSLv2Hello, protocol }, engineRef.get().getEnabledProtocols());
+            socket.getSession().invalidate();
+            socket.close();
+            serverSocket.close();
+            acceptThread.join();
+        }
+    }
+
+    @Test
+    public void testNoTLS13CipherSuitesEnabled() throws IOException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        testEnabledCipherSuites(new String[] { "ALL" }, false); // only enable TLS v1.2 cipher suites
+    }
+
+    @Test
+    public void testBothTLS12AndTLS13CipherSuitesEnabled() throws IOException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        testEnabledCipherSuites(new String[] { "TLS_AES_128_GCM_SHA256", "ALL" }, true);
+    }
+
+    @Test
+    public void testTLS13CipherSuiteEnabled() throws IOException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        testEnabledCipherSuites(new String[] { "TLS_AES_128_GCM_SHA256" }, true);
+    }
+
+    @Test
+    public void testTLS13UsedByDefault() throws IOException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        testEnabledCipherSuites(new String[] { "TLS_AES_128_GCM_SHA256" }, true);
+    }
+
+
+    private void testEnabledCipherSuites(String[] cipherSuites, boolean tls13Expected) throws IOException, InterruptedException {
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
+            final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
+
+            EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
+                engineRef.set(engine);
+                try {
+                    if (! tls13Expected) {
+                        engine.setEnabledProtocols(new String[]{ "TLSv1.2"});
+                    }
+                    engine.setEnabledCipherSuites(cipherSuites);
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Thread acceptThread = new Thread(echo);
+            acceptThread.start();
+            final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
+            socket.connect(SSLTestUtils.createSocketAddress());
+            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+            byte[] data = new byte[100];
+            int read = socket.getInputStream().read(data);
+
+            Assert.assertEquals(MESSAGE, new String(data, 0, read));
+            if (! tls13Expected) {
+                Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+                Assert.assertEquals("TLSv1.2", socket.getSession().getProtocol());
+                Assert.assertEquals(false, CipherSuiteConverter.isTLSv13CipherSuite(socket.getSession().getCipherSuite()));
+            } else {
+                Assert.assertEquals("TLSv1.3", socket.getSession().getProtocol());
+                Assert.assertEquals(true, CipherSuiteConverter.isTLSv13CipherSuite(socket.getSession().getCipherSuite()));
+                Assert.assertEquals(cipherSuites[0], socket.getSession().getCipherSuite());
+            }
+
+            socket.getSession().invalidate();
+            socket.close();
+            serverSocket.close();
+            acceptThread.join();
         }
     }
 
@@ -162,6 +302,7 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
             Thread acceptThread = new Thread(echo);
             acceptThread.start();
             SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
             socket.setEnabledProtocols(new String[] { "TLSv1" }); // from list of enabled protocols on the server side
             socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
@@ -176,6 +317,7 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
             socket.close();
 
             socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
             socket.setEnabledProtocols(new String[] { "TLSv1.1" }); // from list of enabled protocols on the server side
             socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
@@ -196,6 +338,7 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
 
     @Test
     public void testMultipleEnabledProtocolsWithClientProtocolWithinEnabledRange() throws IOException, InterruptedException {
+        Assume.assumeTrue(! isOpenSSL10() && ! isOpenSSL110FOrLower());
         final String[] protocols = new String[] { "TLSv1", "TLSv1.2" };
 
         try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
@@ -216,6 +359,7 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
             acceptThread.start();
 
             SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
             socket.setEnabledProtocols(new String[] { "TLSv1.1" });
             socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
@@ -225,7 +369,7 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
             Assert.assertEquals(MESSAGE, new String(data, 0, read));
             Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
             Assert.assertEquals("TLSv1.1", socket.getSession().getProtocol());
-            Assert.assertArrayEquals(new String[]{ SSL_PROTO_SSLv2Hello, "TLSv1", "TLSv1.1", "TLSv1.2" }, engineRef.get().getEnabledProtocols());
+            Assert.assertArrayEquals(new String[]{SSL_PROTO_SSLv2Hello, "TLSv1", "TLSv1.1", "TLSv1.2"}, engineRef.get().getEnabledProtocols());
 
             socket.getSession().invalidate();
             socket.close();
@@ -255,27 +399,37 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
             Thread acceptThread = new Thread(echo);
             acceptThread.start();
 
+            SSLSocket socket = null;
             try {
-                SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                socket.setReuseAddress(true);
                 socket.setEnabledProtocols(new String[]{"SSLv3"});
                 socket.connect(SSLTestUtils.createSocketAddress());
                 socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
                 Assert.fail("Expected SSLHandshakeException not thrown");
             } catch (SSLHandshakeException e) {
                 // expected
+                if (socket != null) {
+                    socket.close();
+                }
             }
             try {
-                SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                socket.setReuseAddress(true);
                 socket.setEnabledProtocols(new String[]{"TLSv1"});
                 socket.connect(SSLTestUtils.createSocketAddress());
                 socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
                 Assert.fail("Expected SSLHandshakeException not thrown");
             } catch (SSLHandshakeException e) {
                 // expected
+                if (socket != null) {
+                    socket.close();
+                }
             }
             try {
                 if (getJavaSpecVersion() >= 11) {
-                    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                    socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                    socket.setReuseAddress(true);
                     socket.setEnabledProtocols(new String[]{"TLSv1.3"});
                     socket.connect(SSLTestUtils.createSocketAddress());
                     socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
@@ -283,6 +437,9 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
                 }
             } catch (SSLHandshakeException e) {
                 // expected
+                if (socket != null) {
+                    socket.close();
+                }
             }
 
             serverSocket.close();
@@ -290,7 +447,7 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
         }
     }
 
-    @Test(expected = SSLException.class)
+    @Test
     public void testWrongClientSideTrustManagerFailsValidation() throws IOException, NoSuchAlgorithmException, InterruptedException {
         try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
@@ -299,9 +456,64 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
             Thread acceptThread = new Thread(new EchoRunnable(serverSocket, sslContext, sessionID));
             acceptThread.start();
             final SSLSocket socket = (SSLSocket) SSLTestUtils.createSSLContext("openssl.TLSv1").getSocketFactory().createSocket();
+            socket.setReuseAddress(true);
             socket.setSSLParameters(socket.getSSLParameters());
             socket.connect(SSLTestUtils.createSocketAddress());
-            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+            try {
+                socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+                Assert.fail("Expected SSLException not thrown");
+            } catch (SSLException expected) {
+                socket.close();
+                serverSocket.close();
+                acceptThread.join();
+            }
+        }
+    }
+
+
+    @Test
+    public void openSslLotsOfDataTest() throws IOException, NoSuchAlgorithmException, InterruptedException {
+        final String[] protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+        for (String protocol : protocols) {
+            openSslLotsOfDataTestBase(protocol);
+        }
+    }
+
+    @Test
+    public void openSslLotsOfDataTestTLS13() throws IOException, NoSuchAlgorithmException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        openSslLotsOfDataTestBase("TLSv1.3");
+    }
+
+    private void openSslLotsOfDataTestBase(String protocol) throws IOException, NoSuchAlgorithmException, InterruptedException {
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
+
+            final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
+            EchoRunnable target = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
+                engineRef.set(engine);
+                try {
+                    engine.setEnabledProtocols(new String[]{ protocol }); // only one protocol enabled on server side
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Thread acceptThread = new Thread(target);
+            acceptThread.start();
+            final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
+            socket.connect(SSLTestUtils.createSocketAddress());
+            String message = generateMessage(1000);
+            socket.getOutputStream().write(message.getBytes(StandardCharsets.US_ASCII));
+            socket.getOutputStream().write(new byte[]{0});
+
+            Assert.assertEquals(message, new String(SSLTestUtils.readData(socket.getInputStream())));
+            if (! isTLS13Supported()) {
+                Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+            }
+
             socket.getSession().invalidate();
             socket.close();
             serverSocket.close();
@@ -309,29 +521,77 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
         }
     }
 
-
     @Test
-    public void openSslLotsOfDataTest() throws IOException, NoSuchAlgorithmException, InterruptedException {
-        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
-            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
-            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1");
-
-            EchoRunnable target = new EchoRunnable(serverSocket, sslContext, sessionID);
-            Thread acceptThread = new Thread(target);
-            acceptThread.start();
-            final SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-            socket.connect(SSLTestUtils.createSocketAddress());
-            String message = generateMessage(1000);
-            socket.getOutputStream().write(message.getBytes(StandardCharsets.US_ASCII));
-            socket.getOutputStream().write(new byte[]{0});
-
-            Assert.assertEquals(message, new String(SSLTestUtils.readData(socket.getInputStream())));
-            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
-
-            serverSocket.close();
-            acceptThread.join();
+    public void testTwoWay() throws Exception {
+        final String[] protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2", "TLS" };
+        for (String protocol : protocols) {
+            performTestTwoWay("openssl." + protocol, "openssl." + protocol, protocol);
         }
     }
+
+    @Test
+    public void testTwoWayTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        performTestTwoWay("openssl.TLSv1.3", "openssl.TLSv1.3", "TLSv1.3");
+    }
+
+    @Test
+    public void testTwoWayInterop() throws Exception {
+        final String[] protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+        for (String protocol : protocols) {
+            performTestTwoWay("openssl." + protocol, protocol, protocol); // openssl server
+        }
+        for (String protocol : protocols) {
+            performTestTwoWay(protocol, "openssl." + protocol, protocol); // openssl client
+        }
+    }
+
+    @Test
+    public void testTwoWayInteropTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        performTestTwoWay("openssl.TLSv1.3", "TLSv1.3", "TLSv1.3"); // openssl server
+        performTestTwoWay("TLSv1.3", "openssl.TLSv1.3", "TLSv1.3"); // openssl client
+    }
+
+    private void performTestTwoWay(String serverProvider, String clientProvider, String protocol) throws Exception {
+        final SSLContext serverContext = SSLTestUtils.createSSLContext(serverProvider);
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<SSLSocket> socketFuture = executorService.submit(() -> {
+            try {
+                SSLContext clientContext = SSLTestUtils.createClientSSLContext(clientProvider);
+                SSLSocket sslSocket = (SSLSocket) clientContext.getSocketFactory().createSocket(HOST, PORT);
+                sslSocket.setReuseAddress(true);
+                sslSocket.getSession();
+                return sslSocket;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        SSLServerSocket sslServerSocket = (SSLServerSocket) serverContext.getServerSocketFactory().createServerSocket(PORT, 10, InetAddress.getByName(HOST));
+        SSLSocket serverSocket = (SSLSocket) sslServerSocket.accept();
+        SSLSession serverSession = serverSocket.getSession();
+        SSLSocket clientSocket = socketFuture.get();
+        SSLSession clientSession = clientSocket.getSession();
+
+        try {
+            String expectedProtocol;
+            if (protocol.equals("TLS")) {
+                expectedProtocol = isTLS13Supported() ? "TLSv1.3" : "TLSv1.2";
+            } else {
+                expectedProtocol = protocol;
+            }
+            Assert.assertEquals(expectedProtocol, clientSession.getProtocol());
+            Assert.assertEquals(expectedProtocol, serverSession.getProtocol());
+            Assert.assertEquals(expectedProtocol.equals("TLSv1.3"), CipherSuiteConverter.isTLSv13CipherSuite(clientSession.getCipherSuite()));
+            Assert.assertEquals(expectedProtocol.equals("TLSv1.3"), CipherSuiteConverter.isTLSv13CipherSuite(serverSession.getCipherSuite()));
+        } finally {
+            serverSocket.close();
+            clientSocket.close();
+            sslServerSocket.close();
+        }
+    }
+
 
     private static String generateMessage(int repetitions) {
         final StringBuilder builder = new StringBuilder(repetitions * MESSAGE.length());

--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketDSATest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketDSATest.java
@@ -55,6 +55,7 @@ public class BasicOpenSSLSocketDSATest extends AbstractOpenSSLTest {
             acceptThread.start();
             final SSLContext sslContext = SSLTestUtils.createClientDSASSLContext("openssl.TLSv1.2");
             final SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
+            socket.setReuseAddress(true);
             socket.setEnabledCipherSuites(new String[] {"TLS_DHE_DSS_WITH_AES_128_CBC_SHA256"});
             socket.connect(SSLTestUtils.createSocketAddress());
             socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
@@ -65,6 +66,8 @@ public class BasicOpenSSLSocketDSATest extends AbstractOpenSSLTest {
             Assert.assertEquals("hello world", new String(data, 0, read));
             //TODO: fix client session id
             //Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+            socket.getSession().invalidate();
+            socket.close();
             serverSocket.close();
             acceptThread.join();
         }
@@ -81,6 +84,7 @@ public class BasicOpenSSLSocketDSATest extends AbstractOpenSSLTest {
             final SSLContext sslContext = SSLTestUtils.createClientDSASSLContext("openssl.TLSv1");
             InetSocketAddress socketAddress = (InetSocketAddress) SSLTestUtils.createSocketAddress();
             final SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket(socketAddress.getAddress(), socketAddress.getPort());
+            socket.setReuseAddress(true);
             socket.setEnabledCipherSuites(new String[] {"TLS_DHE_DSS_WITH_AES_128_CBC_SHA"});
             socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
             socket.getOutputStream().flush();
@@ -90,8 +94,11 @@ public class BasicOpenSSLSocketDSATest extends AbstractOpenSSLTest {
             Assert.assertEquals("hello world", new String(data, 0, read));
             //TODO: fix client session id
             //Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+            socket.getSession().invalidate();
+            socket.close();
             serverSocket.close();
             acceptThread.join();
         }
     }
+
 }

--- a/java/src/test/java/org/wildfly/openssl/ClientSessionInteropTest.java
+++ b/java/src/test/java/org/wildfly/openssl/ClientSessionInteropTest.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.openssl;
+
+import static org.wildfly.openssl.OpenSSLEngine.isTLS13Supported;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class ClientSessionInteropTest extends ClientSessionTestBase {
+
+    @Test
+    public void testJsse() throws Exception {
+        final String[] providers = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" }; // testing session id doesn't make sense for TLSv1.3 or higher
+        for (String provider : providers) {
+            testSessionId(SSLTestUtils.createSSLContext(provider), "openssl." + provider);
+        }
+    }
+
+    @Test
+    public void testSessionTimeoutJsse() throws Exception {
+        testSessionTimeout("TLSv1", "openssl.TLSv1");
+    }
+
+    @Test
+    public void testSessionTimeoutJsseTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        testSessionTimeoutTLS13("TLSv1.3", "openssl.TLSv1.3");
+    }
+
+    @Test
+    public void testSessionInvalidationJsse() throws Exception {
+        final String[] providers = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+        for (String provider : providers) {
+            testSessionInvalidation(provider, "openssl." + provider);
+        }
+    }
+
+    @Test
+    public void testSessionInvalidationJsseTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        testSessionInvalidationTLS13("TLSv1.3", "openssl.TLSv1.3");
+    }
+
+    @Test
+    public void testSessionSizeJsse() throws Exception {
+        final String[] providers = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
+        for (String provider : providers) {
+            testSessionSize(provider, "openssl." + provider);
+        }
+    }
+
+    @Test
+    public void testSessionSizeJsseTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        testSessionSizeTLS13("TLSv1.3", "openssl.TLSv1.3");
+    }
+
+    /**
+     * Tests that invalidation of a client session, for whatever reason, when multiple threads
+     * are involved in interacting with the server through a SSL socket, doesn't lead to a JVM crash
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testClientSessionInvalidationMultiThreadAccessJsse() throws Exception {
+        testClientSessionInvalidationMultiThreadAccess("TLSv1.2", "openssl." + "TLSv1.2");
+    }
+
+    @Test
+    public void testClientSessionInvalidationMultiThreadAccessJsseTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        testClientSessionInvalidationMultiThreadAccess("TLSv1.3" , "openssl.TLSv1.3");
+    }
+
+}

--- a/java/src/test/java/org/wildfly/openssl/ClientSessionTest.java
+++ b/java/src/test/java/org/wildfly/openssl/ClientSessionTest.java
@@ -19,339 +19,72 @@
 
 package org.wildfly.openssl;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.wildfly.openssl.OpenSSLEngine.isTLS13Supported;
 
-import javax.net.ssl.HandshakeCompletedEvent;
-import javax.net.ssl.HandshakeCompletedListener;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSessionContext;
-import javax.net.ssl.SSLSocket;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Assume;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class ClientSessionTest extends AbstractOpenSSLTest {
-
-    private static final byte[] HELLO_WORLD = "hello world".getBytes(StandardCharsets.US_ASCII);
-
-    @Test
-    public void testJsse() throws Exception {
-        testSessionId(SSLTestUtils.createSSLContext("TLSv1"));
-    }
+public class ClientSessionTest extends ClientSessionTestBase {
 
     @Test
     public void testOpenSsl() throws Exception {
-        testSessionId(SSLTestUtils.createSSLContext("openssl.TLSv1"));
-    }
-
-    @Test
-    public void testSessionTimeout() throws Exception {
-        final int port1 = SSLTestUtils.PORT;
-        final int port2 = SSLTestUtils.SECONDARY_PORT;
-
-        try (
-                ServerSocket serverSocket1 = SSLTestUtils.createServerSocket(port1);
-                ServerSocket serverSocket2 = SSLTestUtils.createServerSocket(port2)
-        ) {
-
-            final Thread acceptThread1 = startServer(serverSocket1);
-            final Thread acceptThread2 = startServer(serverSocket2);
-
-            SSLContext clientContext = SSLTestUtils.createClientSSLContext("openssl.TLSv1");
-            final SSLSessionContext clientSession = clientContext.getClientSessionContext();
-            byte[] host1SessionId = connectAndWrite(clientContext, port1);
-            byte[] host2SessionId = connectAndWrite(clientContext, port2);
-
-            // No timeout was set, id's should be identical
-            Assert.assertArrayEquals(host1SessionId, connectAndWrite(clientContext, port1));
-            Assert.assertArrayEquals(host2SessionId, connectAndWrite(clientContext, port2));
-
-            // Set the session timeout to 1 second and sleep for 2 to ensure the timeout works
-            clientSession.setSessionTimeout(1);
-            TimeUnit.SECONDS.sleep(2L);
-            Assert.assertFalse(Arrays.equals(host1SessionId, connectAndWrite(clientContext, port1)));
-            Assert.assertFalse(Arrays.equals(host1SessionId, connectAndWrite(clientContext, port2)));
-
-            serverSocket1.close();
-            serverSocket2.close();
-            acceptThread1.join();
-            acceptThread2.join();
+        final String[] providers = new String[] { "openssl.TLSv1", "openssl.TLSv1.1", "openssl.TLSv1.2"}; // testing session id doesn't make sense for TLSv1.3 or higher
+        for (String provider : providers) {
+            testSessionId(SSLTestUtils.createSSLContext(provider), provider);
         }
     }
 
     @Test
-    public void testSessionInvalidation() throws Exception {
-        final int port = SSLTestUtils.PORT;
+    public void testSessionTimeoutOpenSsl() throws Exception {
+        testSessionTimeout("openssl.TLSv1", "openssl.TLSv1");
+    }
 
-        try (ServerSocket serverSocket1 = SSLTestUtils.createServerSocket(port)) {
+    @Test
+    public void testSessionTimeoutOpenSslTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        testSessionTimeoutTLS13("openssl.TLSv1.3", "openssl.TLSv1.3");
+    }
 
-            final Thread acceptThread1 = startServer(serverSocket1);
-            final FutureSessionId future = new FutureSessionId();
-            SSLContext clientContext = SSLTestUtils.createClientSSLContext("openssl.TLSv1");
-            try (SSLSocket socket = (SSLSocket) clientContext.getSocketFactory().createSocket()) {
-                socket.connect(new InetSocketAddress(SSLTestUtils.HOST, port));
-                socket.addHandshakeCompletedListener(new FutureHandshakeCompletedListener(future));
-                socket.getOutputStream().write(HELLO_WORLD);
-                socket.getSession().invalidate();
-                socket.getOutputStream().flush();
-            }
-            byte[] invalided = future.get();
-            byte[] newSession = connectAndWrite(clientContext, port);
-
-            Assert.assertFalse(Arrays.equals(invalided, newSession));
-
-            serverSocket1.close();
-            acceptThread1.join();
+    @Test
+    public void testSessionInvalidationOpenSsl() throws Exception {
+        final String[] providers = new String[] { "openssl.TLSv1", "openssl.TLSv1.1", "openssl.TLSv1.2" };
+        for (String provider : providers) {
+            testSessionInvalidation(provider, provider);
         }
     }
 
     @Test
-    public void testSessionSize() throws Exception {
-        final int port1 = SSLTestUtils.PORT;
-        final int port2 = SSLTestUtils.SECONDARY_PORT;
-
-        try (
-                ServerSocket serverSocket1 = SSLTestUtils.createServerSocket(port1);
-                ServerSocket serverSocket2 = SSLTestUtils.createServerSocket(port2)
-        ) {
-
-            final Thread acceptThread1 = startServer(serverSocket1);
-            final Thread acceptThread2 = startServer(serverSocket2);
-            SSLContext clientContext = SSLTestUtils.createClientSSLContext("openssl.TLSv1");
-
-            final SSLSessionContext clientSession = clientContext.getClientSessionContext();
-
-            byte[] host1SessionId = connectAndWrite(clientContext, port1);
-            byte[] host2SessionId = connectAndWrite(clientContext, port2);
-
-            // No cache limit was set, id's should be identical
-            Assert.assertArrayEquals(host1SessionId, connectAndWrite(clientContext, port1));
-            Assert.assertArrayEquals(host2SessionId, connectAndWrite(clientContext, port2));
-
-            // Set the cache size to 1
-            clientSession.setSessionCacheSize(1);
-            // The second session id should be the one kept as it was the last one used
-            Assert.assertArrayEquals(host2SessionId, connectAndWrite(clientContext, port2));
-            // Connect again to the first host, this should not match the initial session id for the first host
-            byte[] nextId = connectAndWrite(clientContext, port1);
-            Assert.assertFalse(Arrays.equals(host1SessionId, nextId));
-            // Once more connect to the first host and this should match the previous session id
-            Assert.assertArrayEquals(nextId, connectAndWrite(clientContext, port1));
-            // Connect to the second host which should be purged at this point
-            Assert.assertFalse(Arrays.equals(nextId, connectAndWrite(clientContext, port2)));
-
-            // Reset the cache limit and ensure both sessions are cached
-            clientSession.setSessionCacheSize(0);
-            host1SessionId = connectAndWrite(clientContext, port1);
-            host2SessionId = connectAndWrite(clientContext, port2);
-
-            // No cache limit was set, id's should be identical
-            Assert.assertArrayEquals(host1SessionId, connectAndWrite(clientContext, port1));
-            Assert.assertArrayEquals(host2SessionId, connectAndWrite(clientContext, port2));
-
-            serverSocket1.close();
-            serverSocket2.close();
-            acceptThread1.join();
-            acceptThread2.join();
-        }
+    public void testSessionInvalidationOpenSslTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        testSessionInvalidationTLS13("openssl.TLSv1.3", "openssl.TLSv1.3");
     }
 
-
-    /**
-     * Tests that invalidation of a client session, for whatever reason, when multiple threads
-     * are involved in interacting with the server through a SSL socket, doesn't lead to a JVM crash
-     *
-     * @throws Exception
-     */
     @Test
-    public void testClientSessionInvalidationMultiThreadAccess() throws Exception {
-        final int port = SSLTestUtils.PORT;
-        final int numThreads = 10;
-        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
-        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket(port)) {
-            final Thread acceptThread = startServer(serverSocket);
-            final SSLContext clientContext = SSLTestUtils.createClientSSLContext("openssl.TLSv1.2");
-            final List<Future<Void>> taskResults = new ArrayList<>();
-            for (int i = 0; i < numThreads; i++) {
-                taskResults.add(executor.submit(new SocketWriter(clientContext, SSLTestUtils.HOST, port)));
-            }
-            // wait for results
-            for (int i = 0; i < numThreads; i++) {
-                taskResults.get(i).get(10, TimeUnit.SECONDS);
-            }
-            serverSocket.close();
-            acceptThread.join();
-        } finally {
-            executor.shutdownNow();
+    public void testSessionSizeOpenSsl() throws Exception {
+        final String[] providers = new String[] { "openssl.TLSv1", "openssl.TLSv1.1", "openssl.TLSv1.2"};
+        for (String provider : providers) {
+            testSessionSize(provider, provider);
         }
     }
 
-    private void testSessionId(final SSLContext sslContext) throws IOException, InterruptedException {
-        final int iterations = 10;
-        final Collection<SSLSocket> toClose = new ArrayList<>();
-
-        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
-
-            final Thread acceptThread = new Thread(new EchoRunnable(serverSocket, sslContext, new AtomicReference<>()));
-            acceptThread.start();
-
-            byte[] sessionID;
-            // Create a connection to get a session ID, all other session id's should match
-            SSLContext clientContext = SSLTestUtils.createClientSSLContext("openssl.TLSv1");
-            try (SSLSocket socket = (SSLSocket) clientContext.getSocketFactory().createSocket()) {
-                socket.connect(SSLTestUtils.createSocketAddress());
-                socket.startHandshake();
-                final byte[] id = socket.getSession().getId();
-                sessionID = Arrays.copyOf(id, id.length);
-            }
-
-            final CountDownLatch latch = new CountDownLatch(iterations);
-
-            for (int i = 0; i < iterations; i++) {
-                final SSLSocket socket = (SSLSocket) clientContext.getSocketFactory().createSocket();
-                socket.connect(SSLTestUtils.createSocketAddress());
-                socket.addHandshakeCompletedListener(new AssertingHandshakeCompletedListener(latch, sessionID));
-                socket.startHandshake();
-                toClose.add(socket);
-            }
-            if (!latch.await(30, TimeUnit.SECONDS)) {
-                Assert.fail("Failed to complete handshakes");
-            }
-            serverSocket.close();
-            acceptThread.join(1000);
-        } finally {
-            for (SSLSocket socket : toClose) {
-                try {
-                    socket.close();
-                } catch (Exception ignore) {
-                }
-            }
-        }
-
+    @Test
+    public void testSessionSizeOpenSslTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        testSessionSizeTLS13("openssl.TLSv1.3", "openssl.TLSv1.3");
     }
 
-    private byte[] connectAndWrite(final SSLContext context, final int port) throws IOException, ExecutionException, InterruptedException {
-        final FutureSessionId future = new FutureSessionId();
-        try (SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket()) {
-            socket.connect(new InetSocketAddress(SSLTestUtils.HOST, port));
-            socket.addHandshakeCompletedListener(new FutureHandshakeCompletedListener(future));
-            socket.getOutputStream().write(HELLO_WORLD);
-            socket.getOutputStream().flush();
-        }
-        return future.get();
+    @Test
+    public void testClientSessionInvalidationMultiThreadAccessOpenSsl() throws Exception {
+        testClientSessionInvalidationMultiThreadAccess("openssl.TLSv1.2", "openssl.TLSv1.2");
     }
 
-    private static class AssertingHandshakeCompletedListener implements HandshakeCompletedListener {
-        private final CountDownLatch latch;
-        private final byte[] expectedSessionId;
-
-        private AssertingHandshakeCompletedListener(final CountDownLatch latch, final byte[] expectedSessionId) {
-            this.latch = latch;
-            this.expectedSessionId = expectedSessionId;
-        }
-
-        @Override
-        public void handshakeCompleted(final HandshakeCompletedEvent event) {
-            latch.countDown();
-            Assert.assertArrayEquals(expectedSessionId, event.getSession().getId());
-        }
+    @Test
+    public void testClientSessionInvalidationMultiThreadAccessOpenSslTLS13() throws Exception {
+        Assume.assumeTrue(isTLS13Supported());
+        testClientSessionInvalidationMultiThreadAccess("openssl.TLSv1.3", "openssl.TLSv1.3");
     }
 
-    private Thread startServer(final ServerSocket serverSocket) throws IOException {
-        final Thread acceptThread = new Thread(new EchoRunnable(serverSocket, SSLTestUtils.createSSLContext("TLSv1"), new AtomicReference<>()));
-        acceptThread.start();
-        return acceptThread;
-    }
-
-    private static class FutureHandshakeCompletedListener implements HandshakeCompletedListener {
-        private final FutureSessionId futureSessionId;
-
-        private FutureHandshakeCompletedListener(final FutureSessionId futureSessionId) {
-            this.futureSessionId = futureSessionId;
-        }
-
-        @Override
-        public void handshakeCompleted(final HandshakeCompletedEvent event) {
-            futureSessionId.value = event.getSession().getId();
-        }
-    }
-
-    private static class FutureSessionId implements Future<byte[]> {
-        private final AtomicBoolean done = new AtomicBoolean(false);
-        private volatile byte[] value;
-
-        @Override
-        public boolean cancel(final boolean mayInterruptIfRunning) {
-            return false;
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return false;
-        }
-
-        @Override
-        public boolean isDone() {
-            return done.get();
-        }
-
-        @Override
-        public byte[] get() throws InterruptedException, ExecutionException {
-            while (value == null) {
-                TimeUnit.MILLISECONDS.sleep(10L);
-            }
-            done.set(true);
-            return value;
-        }
-
-        @Override
-        public byte[] get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-            return get();
-        }
-    }
-
-    private class SocketWriter implements Callable<Void> {
-        private final SSLContext sslClientContext;
-        private final String host;
-        private final int port;
-
-        SocketWriter(final SSLContext sslClientContext, final String host, final int port) {
-            this.sslClientContext = sslClientContext;
-            this.host = host;
-            this.port = port;
-        }
-
-        @Override
-        public Void call() {
-            // create a socket, connect, write some data, invalidate the session
-            try (SSLSocket socket = (SSLSocket) this.sslClientContext.getSocketFactory().createSocket()) {
-                socket.connect(new InetSocketAddress(this.host, this.port));
-                socket.getOutputStream().write(HELLO_WORLD);
-                socket.getOutputStream().flush();
-                socket.getSession().invalidate();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return null;
-        }
-    }
 }

--- a/java/src/test/java/org/wildfly/openssl/ClientSessionTestBase.java
+++ b/java/src/test/java/org/wildfly/openssl/ClientSessionTestBase.java
@@ -1,0 +1,624 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.openssl;
+
+import static org.wildfly.openssl.OpenSSLEngine.isTLS13Supported;
+import static org.wildfly.openssl.SSLTestUtils.HOST;
+import static org.wildfly.openssl.SSLTestUtils.PORT;
+
+import org.junit.Assert;
+
+import javax.net.ssl.HandshakeCompletedEvent;
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLSocket;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class ClientSessionTestBase extends AbstractOpenSSLTest {
+
+    private static final byte[] HELLO_WORLD = "hello world".getBytes(StandardCharsets.US_ASCII);
+
+    void testSessionTimeout(String serverProvider, String clientProvider) throws Exception {
+        final int port1 = PORT;
+        final int port2 = SSLTestUtils.SECONDARY_PORT;
+
+        try (
+                ServerSocket serverSocket1 = SSLTestUtils.createServerSocket(port1);
+                ServerSocket serverSocket2 = SSLTestUtils.createServerSocket(port2)
+        ) {
+
+            final Thread acceptThread1 = startServer(serverSocket1, serverProvider);
+            final Thread acceptThread2 = startServer(serverSocket2, serverProvider);
+
+            SSLContext clientContext = SSLTestUtils.createClientSSLContext(clientProvider);
+            final SSLSessionContext clientSession = clientContext.getClientSessionContext();
+            byte[] host1SessionId = connectAndWrite(clientContext, port1);
+            byte[] host2SessionId = connectAndWrite(clientContext, port2);
+
+            // No timeout was set, id's should be identical
+            Assert.assertArrayEquals(host1SessionId, connectAndWrite(clientContext, port1));
+            Assert.assertArrayEquals(host2SessionId, connectAndWrite(clientContext, port2));
+
+            // Set the session timeout to 1 second and sleep for 2 to ensure the timeout works
+            clientSession.setSessionTimeout(1);
+            TimeUnit.SECONDS.sleep(2L);
+            Assert.assertFalse(Arrays.equals(host1SessionId, connectAndWrite(clientContext, port1)));
+            Assert.assertFalse(Arrays.equals(host1SessionId, connectAndWrite(clientContext, port2)));
+
+            serverSocket1.close();
+            serverSocket2.close();
+            acceptThread1.join();
+            acceptThread2.join();
+        }
+    }
+
+    void testSessionTimeoutTLS13(String serverProvider, String clientProvider) throws Exception {
+        final int port1 = PORT;
+        final int port2 = SSLTestUtils.SECONDARY_PORT;
+        Server server1 = startServerTLS13(serverProvider, port1);
+        Server server2 = startServerTLS13(serverProvider, port2);
+        server1.signal();
+        server2.signal();
+        SSLContext clientContext = SSLTestUtils.createClientSSLContext(clientProvider);
+        SSLSessionContext clientSession = clientContext.getClientSessionContext();
+        while (! server1.started) {
+            Thread.yield();
+        }
+        while (! server2.started) {
+            Thread.yield();
+        }
+        SSLSession firstSession1 = connect(clientContext, port1);
+        Assert.assertFalse(((OpenSSlSession) firstSession1).isReused());
+        SSLSession firstSession2 = connect(clientContext, port2);
+        Assert.assertFalse(((OpenSSlSession) firstSession2).isReused());
+        server1.signal();
+        server2.signal();
+
+        // No timeout was set, sessions should be reused
+        SSLSession secondSession1 = connect(clientContext, port1);
+        Assert.assertTrue(((OpenSSlSession) secondSession1).isReused());
+        SSLSession secondSession2 = connect(clientContext, port2);
+        Assert.assertTrue(((OpenSSlSession) secondSession2).isReused());
+        server1.signal();
+        server2.signal();
+
+        // Set the session timeout to 1 second and sleep for 2 to ensure the timeout works
+        clientSession.setSessionTimeout(1);
+        TimeUnit.SECONDS.sleep(2L);
+        SSLSession thirdSession1 = connect(clientContext, port1);
+        Assert.assertFalse(((OpenSSlSession) thirdSession1).isReused());
+        SSLSession thirdSession2 = connect(clientContext, port2);
+        Assert.assertFalse(((OpenSSlSession) thirdSession2).isReused());
+        thirdSession1.invalidate();
+        thirdSession2.invalidate();
+        server1.go = false;
+        server1.signal();
+        server2.go = false;
+        server2.signal();
+    }
+
+    void testSessionInvalidation(String serverProvider, String clientProvider) throws Exception {
+        final int port = PORT;
+
+        try (ServerSocket serverSocket1 = SSLTestUtils.createServerSocket(port)) {
+
+            final Thread acceptThread1 = startServer(serverSocket1, serverProvider);
+            final FutureSessionId future = new FutureSessionId();
+            SSLContext clientContext = SSLTestUtils.createClientSSLContext(clientProvider);
+            try (SSLSocket socket = (SSLSocket) clientContext.getSocketFactory().createSocket()) {
+                socket.setReuseAddress(true);
+                socket.connect(new InetSocketAddress(SSLTestUtils.HOST, port));
+                socket.addHandshakeCompletedListener(new FutureHandshakeCompletedListener(future));
+                socket.getOutputStream().write(HELLO_WORLD);
+                socket.getSession().invalidate();
+                socket.getOutputStream().flush();
+            }
+            byte[] invalided = future.get();
+            Assert.assertNotNull(invalided);
+            byte[] newSession = connectAndWrite(clientContext, port);
+            Assert.assertNotNull(newSession);
+
+            Assert.assertFalse(Arrays.equals(invalided, newSession));
+
+            serverSocket1.close();
+            acceptThread1.join();
+        }
+    }
+
+    void testSessionInvalidationTLS13(String serverProvider, String clientProvider) throws Exception {
+        final int port1 = PORT;
+
+        Server server = startServerTLS13(serverProvider, port1);
+        server.signal();
+        SSLContext clientContext = SSLTestUtils.createClientSSLContext(clientProvider);
+        SSLSessionContext clientSession = clientContext.getClientSessionContext();
+        while (! server.started) {
+            Thread.yield();
+        }
+        SSLSession firstSession = connect(clientContext, port1);
+        server.signal();
+        Assert.assertTrue(firstSession.isValid());
+        Assert.assertFalse(((OpenSSlSession) firstSession).isReused());
+        firstSession.invalidate();
+        Assert.assertFalse(firstSession.isValid());
+        SSLSession secondSession = connect(clientContext, port1);
+        Assert.assertTrue(secondSession.isValid());
+        Assert.assertFalse(((OpenSSlSession) secondSession).isReused());
+        firstSession.invalidate();
+        secondSession.invalidate();
+        server.go = false;
+        server.signal();
+    }
+
+    void testSessionSize(String serverProvider, String clientProvider) throws Exception {
+        final int port1 = PORT;
+        final int port2 = SSLTestUtils.SECONDARY_PORT;
+
+        try (
+                ServerSocket serverSocket1 = SSLTestUtils.createServerSocket(port1);
+                ServerSocket serverSocket2 = SSLTestUtils.createServerSocket(port2)
+        ) {
+
+            final Thread acceptThread1 = startServer(serverSocket1, serverProvider);
+            final Thread acceptThread2 = startServer(serverSocket2, serverProvider);
+            SSLContext clientContext = SSLTestUtils.createClientSSLContext(clientProvider);
+
+            final SSLSessionContext clientSession = clientContext.getClientSessionContext();
+
+            byte[] host1SessionId = connectAndWrite(clientContext, port1);
+            byte[] host2SessionId = connectAndWrite(clientContext, port2);
+
+            // No cache limit was set, id's should be identical
+            Assert.assertArrayEquals(host1SessionId, connectAndWrite(clientContext, port1));
+            Assert.assertArrayEquals(host2SessionId, connectAndWrite(clientContext, port2));
+
+            // Set the cache size to 1
+            clientSession.setSessionCacheSize(1);
+            // The second session id should be the one kept as it was the last one used
+            Assert.assertArrayEquals(host2SessionId, connectAndWrite(clientContext, port2));
+            // Connect again to the first host, this should not match the initial session id for the first host
+            byte[] nextId = connectAndWrite(clientContext, port1);
+            Assert.assertFalse(Arrays.equals(host1SessionId, nextId));
+            // Once more connect to the first host and this should match the previous session id
+            Assert.assertArrayEquals(nextId, connectAndWrite(clientContext, port1));
+            // Connect to the second host which should be purged at this point
+            Assert.assertFalse(Arrays.equals(nextId, connectAndWrite(clientContext, port2)));
+
+            // Reset the cache limit and ensure both sessions are cached
+            clientSession.setSessionCacheSize(0);
+            host1SessionId = connectAndWrite(clientContext, port1);
+            host2SessionId = connectAndWrite(clientContext, port2);
+
+            // No cache limit was set, id's should be identical
+            Assert.assertArrayEquals(host1SessionId, connectAndWrite(clientContext, port1));
+            Assert.assertArrayEquals(host2SessionId, connectAndWrite(clientContext, port2));
+            serverSocket1.close();
+            serverSocket2.close();
+            acceptThread1.join();
+            acceptThread2.join();
+        }
+    }
+
+    void testSessionSizeTLS13(String serverProvider, String clientProvider) throws Exception {
+        final int port1 = PORT;
+        final int port2 = SSLTestUtils.SECONDARY_PORT;
+
+        Server server1 = startServerTLS13(serverProvider, port1);
+        Server server2 = startServerTLS13(serverProvider, port2);
+        server1.signal();
+        server2.signal();
+
+        SSLContext clientContext = SSLTestUtils.createClientSSLContext(clientProvider);
+        final SSLSessionContext clientSession = clientContext.getClientSessionContext();
+
+        while (! server1.started) {
+            Thread.yield();
+        }
+        while (! server2.started) {
+            Thread.yield();
+        }
+
+        SSLSession host1Session = connect(clientContext, port1);
+        Assert.assertFalse(((OpenSSlSession) host1Session).isReused());
+        SSLSession host2Session = connect(clientContext, port2);
+        Assert.assertFalse(((OpenSSlSession) host2Session).isReused());
+        server1.signal();
+        server2.signal();
+
+        // No cache limit was set, id's should be identical
+        host1Session = connect(clientContext, port1);
+        Assert.assertTrue(((OpenSSlSession) host1Session).isReused());
+        host2Session = connect(clientContext, port2);
+        Assert.assertTrue(((OpenSSlSession) host2Session).isReused());
+        server1.signal();
+        server2.signal();
+
+        // Set the cache size to 1
+        clientSession.setSessionCacheSize(1);
+        // The second session should be the one kept as it was the last one used
+        host2Session = connect(clientContext, port2);
+        Assert.assertTrue(((OpenSSlSession) host2Session).isReused());
+        // Connect again to the first host, this should not match the initial session for the first host
+        SSLSession nextSession = connect(clientContext, port1);
+        Assert.assertFalse(((OpenSSlSession) nextSession).isReused());
+        server1.signal();
+        server2.signal();
+
+        // Once more connect to the first host and this should match the previous session
+        nextSession = connect(clientContext, port1);
+        Assert.assertTrue(((OpenSSlSession) nextSession).isReused());
+        // Connect to the second host which should be purged at this point
+        nextSession = connect(clientContext, port2);
+        Assert.assertFalse(((OpenSSlSession) nextSession).isReused());
+        server1.signal();
+        server2.signal();
+
+        // Reset the cache limit and ensure both sessions are cached
+        clientSession.setSessionCacheSize(0);
+        host1Session = connect(clientContext, port1);
+        Assert.assertFalse(((OpenSSlSession) host1Session).isReused());
+        host2Session = connect(clientContext, port2);
+        Assert.assertTrue(((OpenSSlSession) host2Session).isReused());
+        server1.signal();
+        server2.signal();
+
+        // No cache limit was set, id's should be identical
+        host1Session = connect(clientContext, port1);
+        Assert.assertTrue(((OpenSSlSession) host1Session).isReused());
+        host2Session = connect(clientContext, port2);
+        Assert.assertTrue(((OpenSSlSession) host2Session).isReused());
+        host1Session.invalidate();
+        host2Session.invalidate();
+        server1.go = false;
+        server1.signal();
+        server2.go = false;
+        server2.signal();
+    }
+
+    void testClientSessionInvalidationMultiThreadAccess(String serverProvider, String clientProvider) throws Exception {
+        final int port = PORT;
+        final int numThreads = 10;
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket(port)) {
+            final Thread acceptThread = startServer(serverSocket, serverProvider);
+            final SSLContext clientContext = SSLTestUtils.createClientSSLContext(clientProvider);
+            final List<Future<Void>> taskResults = new ArrayList<>();
+            for (int i = 0; i < numThreads; i++) {
+                taskResults.add(executor.submit(new SocketWriter(clientContext, SSLTestUtils.HOST, port)));
+            }
+            // wait for results
+            for (int i = 0; i < numThreads; i++) {
+                taskResults.get(i).get(10, TimeUnit.SECONDS);
+            }
+            serverSocket.close();
+            acceptThread.join();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    void testSessionId(final SSLContext sslContext, final String provider) throws IOException, InterruptedException {
+        final int iterations = 10;
+        final Collection<SSLSocket> toClose = new ArrayList<>();
+
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+
+            EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, new AtomicReference<>(), (engine -> {
+                try {
+                    engine.setEnabledProtocols(new String[]{ "TLSv1", "TLSv1.1", "TLSv1.2"});
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            final Thread acceptThread = new Thread(echo);
+            acceptThread.start();
+
+            byte[] sessionID;
+            // Create a connection to get a session ID, all other session id's should match
+            SSLContext clientContext = SSLTestUtils.createClientSSLContext(provider);
+            try (SSLSocket socket = (SSLSocket) clientContext.getSocketFactory().createSocket()) {
+                socket.setReuseAddress(true);
+                socket.connect(SSLTestUtils.createSocketAddress());
+                socket.startHandshake();
+                final byte[] id = socket.getSession().getId();
+                sessionID = Arrays.copyOf(id, id.length);
+            }
+
+            final CountDownLatch latch = new CountDownLatch(iterations);
+
+            for (int i = 0; i < iterations; i++) {
+                final SSLSocket socket = (SSLSocket) clientContext.getSocketFactory().createSocket();
+                socket.setReuseAddress(true);
+                socket.connect(SSLTestUtils.createSocketAddress());
+                socket.addHandshakeCompletedListener(new AssertingHandshakeCompletedListener(latch, sessionID, getExpectedProtocolFromProvider(provider)));
+                socket.startHandshake();
+                toClose.add(socket);
+            }
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                Assert.fail("Failed to complete handshakes");
+            }
+            serverSocket.close();
+            echo.stop();
+            acceptThread.join();
+        } finally {
+            for (SSLSocket socket : toClose) {
+                try {
+                    socket.close();
+                } catch (Exception ignore) {
+                }
+            }
+        }
+
+    }
+
+    private byte[] connectAndWrite(final SSLContext context, final int port) throws IOException, ExecutionException, InterruptedException {
+        final FutureSessionId future = new FutureSessionId();
+        try (SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket()) {
+            socket.setReuseAddress(true);
+            socket.connect(new InetSocketAddress(SSLTestUtils.HOST, port));
+            socket.addHandshakeCompletedListener(new FutureHandshakeCompletedListener(future));
+            socket.getOutputStream().write(HELLO_WORLD);
+            socket.getOutputStream().flush();
+        }
+        return future.get();
+    }
+
+    private static class AssertingHandshakeCompletedListener implements HandshakeCompletedListener {
+        private final CountDownLatch latch;
+        private final byte[] expectedSessionId;
+        private final String expectedProtocol;
+
+        private AssertingHandshakeCompletedListener(final CountDownLatch latch, final byte[] expectedSessionId, final String expectedProtocol) {
+            this.latch = latch;
+            this.expectedSessionId = expectedSessionId;
+            this.expectedProtocol = expectedProtocol;
+        }
+
+        @Override
+        public void handshakeCompleted(final HandshakeCompletedEvent event) {
+            latch.countDown();
+            Assert.assertArrayEquals(expectedSessionId, event.getSession().getId());
+            Assert.assertFalse(CipherSuiteConverter.isTLSv13CipherSuite(event.getCipherSuite()));
+            Assert.assertEquals(expectedProtocol, event.getSession().getProtocol());
+        }
+    }
+
+    private Thread startServer(final ServerSocket serverSocket, final String serverProvider) throws IOException {
+        EchoRunnable echo = new EchoRunnable(serverSocket, SSLTestUtils.createSSLContext(serverProvider), new AtomicReference<>(), (engine -> {
+            try {
+                if (isTLS13Supported()) {
+                    engine.setEnabledProtocols(new String[]{"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"});
+                } else {
+                    engine.setEnabledProtocols(new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"});
+                }
+                return engine;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }));
+        final Thread acceptThread = new Thread(echo);
+        acceptThread.start();
+        return acceptThread;
+    }
+
+    private static class FutureHandshakeCompletedListener implements HandshakeCompletedListener {
+        private final FutureSessionId futureSessionId;
+
+        private FutureHandshakeCompletedListener(final FutureSessionId futureSessionId) {
+            this.futureSessionId = futureSessionId;
+        }
+
+        @Override
+        public void handshakeCompleted(final HandshakeCompletedEvent event) {
+            futureSessionId.value = event.getSession().getId();
+        }
+    }
+
+    private static class FutureSessionId implements Future<byte[]> {
+        private final AtomicBoolean done = new AtomicBoolean(false);
+        private volatile byte[] value;
+
+        @Override
+        public boolean cancel(final boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDone() {
+            return done.get();
+        }
+
+        @Override
+        public byte[] get() throws InterruptedException, ExecutionException {
+            while (value == null) {
+                TimeUnit.MILLISECONDS.sleep(10L);
+            }
+            done.set(true);
+            return value;
+        }
+
+        @Override
+        public byte[] get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return get();
+        }
+    }
+
+    private class SocketWriter implements Callable<Void> {
+        private final SSLContext sslClientContext;
+        private final String host;
+        private final int port;
+
+        SocketWriter(final SSLContext sslClientContext, final String host, final int port) {
+            this.sslClientContext = sslClientContext;
+            this.host = host;
+            this.port = port;
+        }
+
+        @Override
+        public Void call() {
+            // create a socket, connect, write some data, invalidate the session
+            try (SSLSocket socket = (SSLSocket) this.sslClientContext.getSocketFactory().createSocket()) {
+                socket.setReuseAddress(true);
+                socket.connect(new InetSocketAddress(this.host, this.port));
+                socket.getOutputStream().write(HELLO_WORLD);
+                socket.getOutputStream().flush();
+                socket.getSession().invalidate();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        }
+    }
+
+    private String getExpectedProtocolFromProvider(String provider) {
+        if (provider.startsWith("openssl.")) {
+            return provider.substring(provider.indexOf(".") + 1);
+        } else {
+            return provider;
+        }
+    }
+
+    private static Server startServerTLS13(String provider, int port) {
+        Server server = new Server(provider, port);
+        new Thread(server).start();
+        return server;
+    }
+
+    private static class Server implements Runnable {
+
+        public volatile boolean go = true;
+        private boolean signal = false;
+        public volatile boolean started = false;
+        private String provider;
+        private int port;
+
+        Server(String provider, int port) {
+            this.provider = provider;
+            this.port = port;
+        }
+
+        private synchronized void waitForSignal() {
+            while (!signal) {
+                try {
+                    wait();
+                } catch (InterruptedException ex) {
+                    // do nothing
+                }
+            }
+            signal = false;
+        }
+        public synchronized void signal() {
+            signal = true;
+            notify();
+        }
+
+        @Override
+        public void run() {
+            try {
+                SSLContext serverContext = SSLTestUtils.createSSLContext(provider);
+                SSLServerSocket sslServerSocket = (SSLServerSocket) serverContext.getServerSocketFactory().createServerSocket(port, 10, InetAddress.getByName(HOST));
+
+                waitForSignal();
+                started = true;
+                while (go) {
+                    try {
+                        System.out.println("Waiting for connection");
+                        Socket sock = sslServerSocket.accept();
+                        BufferedReader reader = new BufferedReader(
+                                new InputStreamReader(sock.getInputStream()));
+                        String line = reader.readLine();
+                        System.out.println("server read: " + line);
+                        PrintWriter out = new PrintWriter(
+                                new OutputStreamWriter(sock.getOutputStream()));
+                        out.println(line);
+                        out.flush();
+                        waitForSignal();
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                    }
+                }
+                sslServerSocket.close();
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    private static SSLSession connect(SSLContext sslContext, int port) {
+
+        try {
+            SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket();
+            socket.setReuseAddress(true);
+            socket.connect(new InetSocketAddress(SSLTestUtils.HOST, port));
+            PrintWriter out = new PrintWriter(
+                    new OutputStreamWriter(socket.getOutputStream()));
+            out.println("message");
+            out.flush();
+            BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(socket.getInputStream()));
+            String inMsg = reader.readLine();
+            System.out.println("Client received: " + inMsg);
+            SSLSession result = socket.getSession();
+            socket.close();
+            return result;
+        } catch (Exception ex) {
+            // unexpected exception
+            throw new RuntimeException(ex);
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <packaging>pom</packaging>
 
     <properties>
+        <jdk.min.version>11</jdk.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.wildfly.checkstyle>1.0.8.Final</version.org.wildfly.checkstyle>
         <version.org.wildfly.openssl.natives>2.0.0.Alpha2-SNAPSHOT</version.org.wildfly.openssl.natives>


### PR DESCRIPTION
OpenSSL 1.1.1 added support for TLS 1.3. This PR adds support for TLS 1.3 to the WildFly OpenSSL provider.

https://issues.redhat.com/browse/WFSSL-16
https://issues.redhat.com/browse/WFSSL-36