### PR TITLE
WFSSL-51 Invalidate the removed session

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/OpenSSLSessionContext.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLSessionContext.java
@@ -113,7 +113,10 @@ abstract class OpenSSLSessionContext implements SSLSessionContext {
     }
 
     synchronized void sessionRemovedCallback(byte[] sessionId) {
-        sessions.remove(new Key(sessionId));
+        OpenSSlSession existing = sessions.remove(new Key(sessionId));
+        if (existing != null) {
+            existing.invalidate();
+        }
     }
 
     public void mergeHandshakeSession(SSLSession handshakeSession, byte[] sessionId) {


### PR DESCRIPTION
This is a new potential fix for WFSSL-51. The previous fix needs to be reverted in the native code (so the previously released natives should be fine). 

There are two ways sessions can be removed from the cache, either by timeout/cache size limits being exceeded, or by explicitly calling invalidate from the java code. 

The old fix would call SSL_SESSION_free in the remove callback, which worked for the timeout case, but in the invalidate case the session had already been freed.

This new approach will hopefully work better.
 