### PR TITLE
[WFSSL-63] Update tests to no longer make use of TLSv1 and TLSv1.1 where possible. For tests where these protocols are needed, ensure that they are re-enabled if necessary

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -116,11 +116,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
 
                 <configuration>
                     <redirectTestOutputToFile>${maven.test.redirectTestOutputToFile}</redirectTestOutputToFile>
-                    <forkMode>once</forkMode>
+                    <reuseForks>false</reuseForks>
                     <systemProperties>
                         <javax.net.ssl.keyStore>src/test/resources/client.keystore</javax.net.ssl.keyStore>
                         <javax.net.ssl.trustStore>src/test/resources/client.truststore</javax.net.ssl.trustStore>

--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineLegacyProtocolsTest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineLegacyProtocolsTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.openssl;
+
+import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL10;
+import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL110FOrLower;
+import static org.wildfly.openssl.OpenSSLProvider.getJavaSpecVersion;
+import static org.wildfly.openssl.SSL.SSL_PROTO_SSLv2Hello;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.security.Security;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests that make use of legacy TLS protocols. Since legacy TLS protocols have been disabled
+ * in newer JDK versions, this test class ensures that these protocols are re-enabled if necessary
+ * to make sure the protocols are actually available for the tests.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  {
+
+    public static final String MESSAGE = "Hello World";
+    public static String disabledAlgorithms;
+
+    @BeforeClass
+    public static void setUp() {
+        disabledAlgorithms = Security.getProperty("jdk.tls.disabledAlgorithms");
+        if (disabledAlgorithms != null && (disabledAlgorithms.contains("TLSv1") || disabledAlgorithms.contains("TLSv1.1"))) {
+            // reset the disabled algorithms to make sure that the protocols required in this test are available
+            Security.setProperty("jdk.tls.disabledAlgorithms", "");
+        }
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        if (disabledAlgorithms != null) {
+            Security.setProperty("jdk.tls.disabledAlgorithms", disabledAlgorithms);
+        }
+    }
+
+    @Test
+    public void testMultipleEnabledProtocolsWithClientProtocolExactMatch() throws IOException, InterruptedException {
+        final String[] protocols = new String[] { "TLSv1", "TLSv1.1" };
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
+            final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
+
+            EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
+                engineRef.set(engine);
+                try {
+                    engine.setEnabledProtocols(protocols);
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Thread acceptThread = new Thread(echo);
+            acceptThread.start();
+
+            SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
+            socket.setEnabledProtocols(new String[]{"TLSv1"}); // from list of enabled protocols on the server side
+            socket.connect(SSLTestUtils.createSocketAddress());
+            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+            byte[] data = new byte[100];
+            int read = socket.getInputStream().read(data);
+
+            Assert.assertEquals(MESSAGE, new String(data, 0, read));
+            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+            Assert.assertEquals("TLSv1", socket.getSession().getProtocol());
+            Assert.assertArrayEquals(new String[]{SSL_PROTO_SSLv2Hello, "TLSv1", "TLSv1.1"}, engineRef.get().getEnabledProtocols());
+            socket.getSession().invalidate();
+            socket.close();
+
+            socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
+            socket.setEnabledProtocols(new String[]{"TLSv1.1"}); // from list of enabled protocols on the server side
+            socket.connect(SSLTestUtils.createSocketAddress());
+            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+            data = new byte[100];
+            read = socket.getInputStream().read(data);
+
+            Assert.assertEquals(MESSAGE, new String(data, 0, read));
+            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+            Assert.assertEquals("TLSv1.1", socket.getSession().getProtocol());
+            Assert.assertArrayEquals(new String[]{SSL_PROTO_SSLv2Hello, "TLSv1", "TLSv1.1"}, engineRef.get().getEnabledProtocols());
+
+            socket.getSession().invalidate();
+            socket.close();
+            serverSocket.close();
+            acceptThread.join();
+        }
+    }
+
+    @Test
+    public void testMultipleEnabledProtocolsWithClientProtocolWithinEnabledRange() throws IOException, InterruptedException {
+        Assume.assumeTrue(! isOpenSSL10() && ! isOpenSSL110FOrLower());
+        final String[] protocols = new String[] { "TLSv1", "TLSv1.2" };
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
+            final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
+
+            EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
+                engineRef.set(engine);
+                try {
+                    engine.setEnabledProtocols(protocols);
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Thread acceptThread = new Thread(echo);
+            acceptThread.start();
+
+            SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+            socket.setReuseAddress(true);
+            socket.setEnabledProtocols(new String[] { "TLSv1.1" });
+            socket.connect(SSLTestUtils.createSocketAddress());
+            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+            byte[] data = new byte[100];
+            int read = socket.getInputStream().read(data);
+
+            Assert.assertEquals(MESSAGE, new String(data, 0, read));
+            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+            Assert.assertEquals("TLSv1.1", socket.getSession().getProtocol());
+            Assert.assertArrayEquals(new String[]{SSL_PROTO_SSLv2Hello, "TLSv1", "TLSv1.1", "TLSv1.2"}, engineRef.get().getEnabledProtocols());
+
+            socket.getSession().invalidate();
+            socket.close();
+            serverSocket.close();
+            acceptThread.join();
+        }
+    }
+
+    @Test
+    public void testMultipleEnabledProtocolsWithClientProtocolOutsideOfEnabledRange() throws IOException, InterruptedException {
+        final String[] protocols = new String[]{"TLSv1.1", "TLSv1.2"};
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
+            final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
+
+            EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
+                engineRef.set(engine);
+                try {
+                    engine.setEnabledProtocols(protocols);
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Thread acceptThread = new Thread(echo);
+            acceptThread.start();
+
+            SSLSocket socket = null;
+            try {
+                socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                socket.setReuseAddress(true);
+                socket.setEnabledProtocols(new String[]{"SSLv3"});
+                socket.connect(SSLTestUtils.createSocketAddress());
+                socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+                Assert.fail("Expected SSLHandshakeException not thrown");
+            } catch (SSLHandshakeException e) {
+                // expected
+                if (socket != null) {
+                    socket.close();
+                }
+            }
+            try {
+                socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                socket.setReuseAddress(true);
+                socket.setEnabledProtocols(new String[]{"TLSv1"});
+                socket.connect(SSLTestUtils.createSocketAddress());
+                socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+                Assert.fail("Expected SSLHandshakeException not thrown");
+            } catch (SSLHandshakeException e) {
+                // expected
+                if (socket != null) {
+                    socket.close();
+                }
+            }
+            try {
+                if (getJavaSpecVersion() >= 11) {
+                    socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+                    socket.setReuseAddress(true);
+                    socket.setEnabledProtocols(new String[]{"TLSv1.3"});
+                    socket.connect(SSLTestUtils.createSocketAddress());
+                    socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+                    Assert.fail("Expected SSLHandshakeException not thrown");
+                }
+            } catch (SSLHandshakeException e) {
+                // expected
+                if (socket != null) {
+                    socket.close();
+                }
+            }
+
+            serverSocket.close();
+            acceptThread.join();
+        }
+    }
+}

--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketTest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketTest.java
@@ -40,10 +40,7 @@ public class BasicOpenSSLSocketTest extends AbstractOpenSSLTest {
 
     @Test
     public void basicOpenSSLTest1() throws IOException, NoSuchAlgorithmException, InterruptedException {
-        final String[] protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
-        for (String protocol : protocols) {
-            basicOpenSSLTest1Base(protocol);
-        }
+        basicOpenSSLTest1Base("TLSv1.2");
     }
 
     @Test
@@ -93,10 +90,7 @@ public class BasicOpenSSLSocketTest extends AbstractOpenSSLTest {
 
     @Test
     public void basicOpenSSLTest2() throws IOException, NoSuchAlgorithmException, InterruptedException {
-        final String[] protocols = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
-        for (String protocol : protocols) {
-            basicOpenSSLTest2Base(protocol);
-        }
+        basicOpenSSLTest2Base("TLSv1.2");
     }
 
     @Test

--- a/java/src/test/java/org/wildfly/openssl/ClientCertTest.java
+++ b/java/src/test/java/org/wildfly/openssl/ClientCertTest.java
@@ -42,7 +42,7 @@ public class ClientCertTest extends AbstractOpenSSLTest {
     public void jsseClientCertTest() throws IOException, NoSuchAlgorithmException, InterruptedException {
         try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
-            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1");
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLSv1.2");
 
             Thread acceptThread = new Thread(new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
                 //engine.setNeedClientAuth(true);

--- a/java/src/test/java/org/wildfly/openssl/ClientSessionInteropTest.java
+++ b/java/src/test/java/org/wildfly/openssl/ClientSessionInteropTest.java
@@ -32,15 +32,12 @@ public class ClientSessionInteropTest extends ClientSessionTestBase {
 
     @Test
     public void testJsse() throws Exception {
-        final String[] providers = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" }; // testing session id doesn't make sense for TLSv1.3 or higher
-        for (String provider : providers) {
-            testSessionId(SSLTestUtils.createSSLContext(provider), "openssl." + provider);
-        }
+        testSessionId(SSLTestUtils.createSSLContext("TLSv1.2"), "openssl.TLSv1.2");
     }
 
     @Test
     public void testSessionTimeoutJsse() throws Exception {
-        testSessionTimeout("TLSv1", "openssl.TLSv1");
+        testSessionTimeout("TLSv1.2", "openssl.TLSv1.2");
     }
 
     @Test
@@ -51,10 +48,7 @@ public class ClientSessionInteropTest extends ClientSessionTestBase {
 
     @Test
     public void testSessionInvalidationJsse() throws Exception {
-        final String[] providers = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
-        for (String provider : providers) {
-            testSessionInvalidation(provider, "openssl." + provider);
-        }
+        testSessionInvalidation("TLSv1.2", "openssl.TLSv1.2");
     }
 
     @Test
@@ -65,10 +59,7 @@ public class ClientSessionInteropTest extends ClientSessionTestBase {
 
     @Test
     public void testSessionSizeJsse() throws Exception {
-        final String[] providers = new String[] { "TLSv1", "TLSv1.1", "TLSv1.2" };
-        for (String provider : providers) {
-            testSessionSize(provider, "openssl." + provider);
-        }
+        testSessionSize("TLSv1.2", "openssl.TLSv1.2");
     }
 
     @Test

--- a/java/src/test/java/org/wildfly/openssl/ClientSessionTest.java
+++ b/java/src/test/java/org/wildfly/openssl/ClientSessionTest.java
@@ -31,15 +31,12 @@ public class ClientSessionTest extends ClientSessionTestBase {
 
     @Test
     public void testOpenSsl() throws Exception {
-        final String[] providers = new String[] { "openssl.TLSv1", "openssl.TLSv1.1", "openssl.TLSv1.2"}; // testing session id doesn't make sense for TLSv1.3 or higher
-        for (String provider : providers) {
-            testSessionId(SSLTestUtils.createSSLContext(provider), provider);
-        }
+        testSessionId(SSLTestUtils.createSSLContext("openssl.TLSv1.2"), "openssl.TLSv1.2");
     }
 
     @Test
     public void testSessionTimeoutOpenSsl() throws Exception {
-        testSessionTimeout("openssl.TLSv1", "openssl.TLSv1");
+        testSessionTimeout("openssl.TLSv1.2", "openssl.TLSv1.2");
     }
 
     @Test
@@ -50,10 +47,7 @@ public class ClientSessionTest extends ClientSessionTestBase {
 
     @Test
     public void testSessionInvalidationOpenSsl() throws Exception {
-        final String[] providers = new String[] { "openssl.TLSv1", "openssl.TLSv1.1", "openssl.TLSv1.2" };
-        for (String provider : providers) {
-            testSessionInvalidation(provider, provider);
-        }
+        testSessionInvalidation("openssl.TLSv1.2", "openssl.TLSv1.2");
     }
 
     @Test
@@ -64,10 +58,7 @@ public class ClientSessionTest extends ClientSessionTestBase {
 
     @Test
     public void testSessionSizeOpenSsl() throws Exception {
-        final String[] providers = new String[] { "openssl.TLSv1", "openssl.TLSv1.1", "openssl.TLSv1.2"};
-        for (String provider : providers) {
-            testSessionSize(provider, provider);
-        }
+        testSessionSize("openssl.TLSv1.2", "openssl.TLSv1.2");
     }
 
     @Test

--- a/java/src/test/java/org/wildfly/openssl/ClientSessionTestBase.java
+++ b/java/src/test/java/org/wildfly/openssl/ClientSessionTestBase.java
@@ -357,7 +357,7 @@ public class ClientSessionTestBase extends AbstractOpenSSLTest {
 
             EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, new AtomicReference<>(), (engine -> {
                 try {
-                    engine.setEnabledProtocols(new String[]{ "TLSv1", "TLSv1.1", "TLSv1.2"});
+                    engine.setEnabledProtocols(new String[]{ "TLSv1.2"});
                     return engine;
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -440,9 +440,9 @@ public class ClientSessionTestBase extends AbstractOpenSSLTest {
         EchoRunnable echo = new EchoRunnable(serverSocket, SSLTestUtils.createSSLContext(serverProvider), new AtomicReference<>(), (engine -> {
             try {
                 if (isTLS13Supported()) {
-                    engine.setEnabledProtocols(new String[]{"TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"});
+                    engine.setEnabledProtocols(new String[]{"TLSv1.2", "TLSv1.3"});
                 } else {
-                    engine.setEnabledProtocols(new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"});
+                    engine.setEnabledProtocols(new String[]{"TLSv1.2"});
                 }
                 return engine;
             } catch (Exception e) {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFSSL-63

With these changes, WildFly OpenSSL can be built successfully on Fedora 33 (i.e., with OpenJDK 11.0.9.1) and with older JDK 11 versions.