### PR TITLE
[WFSSL-65] Remove broken hasOp checks

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/OpenSSLContextSPI.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLContextSPI.java
@@ -152,33 +152,10 @@ public abstract class OpenSSLContextSPI extends SSLContextSpi {
                 // Ignore
             }
             // Disable compression
-            boolean disableCompressionSupported = false;
-            try {
-                disableCompressionSupported = SSL.getInstance().hasOp(SSL.SSL_OP_NO_COMPRESSION);
-                if (disableCompressionSupported) {
-                    SSL.getInstance().setSSLContextOptions(ctx, SSL.SSL_OP_NO_COMPRESSION);
-                }
-            } catch (UnsatisfiedLinkError e) {
-                // Ignore
-            }
-            if (!disableCompressionSupported) {
-                LOG.fine("The version of SSL in use does not support disabling compression");
-            }
+            SSL.getInstance().setSSLContextOptions(ctx, SSL.SSL_OP_NO_COMPRESSION);
 
             // Disable TLS Session Tickets (RFC4507) to protect perfect forward secrecy
-            boolean disableSessionTicketsSupported = false;
-            try {
-                disableSessionTicketsSupported = SSL.getInstance().hasOp(SSL.SSL_OP_NO_TICKET);
-                if (disableSessionTicketsSupported) {
-                    SSL.getInstance().setSSLContextOptions(ctx, SSL.SSL_OP_NO_TICKET);
-                }
-            } catch (UnsatisfiedLinkError e) {
-                // Ignore
-            }
-            if (!disableSessionTicketsSupported) {
-                // OpenSSL is too old to support TLS Session Tickets.
-                LOG.fine("The version of SSL in use does not support disabling session tickets");
-            }
+            SSL.getInstance().setSSLContextOptions(ctx, SSL.SSL_OP_NO_TICKET);
         } catch (Exception e) {
             throw new RuntimeException(Messages.MESSAGES.failedToInitializeSslContext(), e);
         }

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLEngine.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLEngine.java
@@ -1425,20 +1425,8 @@ public final class OpenSSLEngine extends SSLEngine {
 
             // Use server's preference order for ciphers (rather than
             // client's)
-            boolean orderCiphersSupported = false;
-            try {
-                orderCiphersSupported = SSL.getInstance().hasOp(SSL.SSL_OP_CIPHER_SERVER_PREFERENCE);
-                if (orderCiphersSupported) {
-                    if (sslParameters.getUseCipherSuitesOrder()) {
-                        SSL.getInstance().setSSLOptions(ssl, SSL.SSL_OP_CIPHER_SERVER_PREFERENCE);
-                    }
-                }
-            } catch (UnsatisfiedLinkError e) {
-                // Ignore
-            }
-            if (!orderCiphersSupported) {
-                // OpenSSL does not support ciphers ordering.
-                LOG.fine("The version of SSL in use does not support cipher ordering");
+            if (sslParameters.getUseCipherSuitesOrder()) {
+                SSL.getInstance().setSSLOptions(ssl, SSL.SSL_OP_CIPHER_SERVER_PREFERENCE);
             }
 
             if(!clientMode) {


### PR DESCRIPTION
(Note: We should merge #96 and #97 before this one so we can trigger CI for this PR)

Remove broken `hasOp` checks for `SSL_OP_NO_COMPRESSION`, `SSL_OP_NO_TICKET`, and `SSL_OP_CIPHER_SERVER_PREFERENCE` since these ops have been present since before OpenSSL 1.0.1, which is the minimum required OpenSSL library version for WildFly OpenSSL.

This fix ensures that `SSL_OP_NO_TICKET` will always be set which fixes an issue a user ran into when using the WildFly OpenSSL provider with Jetty.

More details and discussions with Stuart can be found here:
https://issues.redhat.com/browse/WFSSL-65