### PR TITLE
[WFSSL-73]  Avoid an IllegalStateException when OpenSSLEngine#getSession is called if the OpenSSLEngine has been shut down

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/OpenSSlSession.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSlSession.java
@@ -296,20 +296,24 @@ class OpenSSlSession implements SSLSession {
     void initialised(long pointer, long ssl, byte[] sessionId) {
         this.sessionPointer = pointer;
         this.sessionId = sessionId;
-        initCreationTime(ssl);
-        initPeerCertChain(ssl);
-        initCipherSuite(ssl);
-        initProtocol(ssl);
-        initReused(ssl);
+        if (ssl != 0) {
+            initCreationTime(ssl);
+            initPeerCertChain(ssl);
+            initCipherSuite(ssl);
+            initProtocol(ssl);
+            initReused(ssl);
+        }
     }
 
     void initialised(long ssl) {
-        initCreationTime(ssl);
-        initSessionId(ssl);
-        initPeerCertChain(ssl);
-        initCipherSuite(ssl);
-        initProtocol(ssl);
-        initReused(ssl);
+        if (ssl != 0) {
+            initCreationTime(ssl);
+            initSessionId(ssl);
+            initPeerCertChain(ssl);
+            initCipherSuite(ssl);
+            initProtocol(ssl);
+            initReused(ssl);
+        }
     }
 
     private void initSessionId(long ssl) {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFSSL-73