### PR TITLE
[WFSSL-78] Fix tests execution with JDK17.

### DIFF
--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineTest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineTest.java
@@ -397,8 +397,8 @@ public class BasicOpenSSLEngineTest extends AbstractOpenSSLTest  {
             Assert.assertEquals(expectedProtocol, serverSession.getProtocol());
             Assert.assertEquals(expectedProtocol.equals("TLSv1.3"), CipherSuiteConverter.isTLSv13CipherSuite(clientSession.getCipherSuite()));
             Assert.assertEquals(expectedProtocol.equals("TLSv1.3"), CipherSuiteConverter.isTLSv13CipherSuite(serverSession.getCipherSuite()));
-            Assert.assertNotNull(clientSession.getPeerCertificateChain());
-            Assert.assertNotNull(serverSession.getPeerCertificateChain());
+            Assert.assertNotNull(clientSession.getPeerCertificates());
+            Assert.assertNotNull(serverSession.getPeerCertificates());
         } finally {
             serverSocket.close();
             clientSocket.close();


### PR DESCRIPTION
https://issues.redhat.com/browse/WFSSL-78

Replace deprecated `getPeerCertificateChain()` [1] method call with
`getPeerCertificates()` [2] method call as advised.

[1] https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/net/ssl/SSLSession.html#getPeerCertificateChain()
[2] https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/net/ssl/SSLSession.html#getPeerCertificates()