### PR TITLE
[WFSSL-76] Add parameter validation in ByteBufferUtils#expand method

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/java/src/main/java/org/wildfly/openssl/ByteBufferUtils.java
+++ b/java/src/main/java/org/wildfly/openssl/ByteBufferUtils.java
@@ -18,6 +18,7 @@
 package org.wildfly.openssl;
 
 import org.wildfly.openssl.util.DirectByteBufferDeallocator;
+import org.wildfly.common.Assert;
 
 import java.nio.ByteBuffer;
 
@@ -54,6 +55,8 @@ public class ByteBufferUtils {
      * need for expansion
      */
     public static ByteBuffer expand(ByteBuffer in, int newSize) {
+        Assert.checkNotNullParam("in", in);
+        Assert.checkMinimumParameter("newSize", 0, newSize);
         if (in.capacity() >= newSize) {
             return in;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
                 <version>4.8.2</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wildfly.common</groupId>
+                <artifactId>wildfly-common</artifactId>
+                <version>1.5.4.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>


### PR DESCRIPTION
[WFSSL-76] Add parameter validation in ByteBufferUtils#expand method
https://issues.redhat.com/browse/WFSSL-76?filter=-1
- add validation for ByteBuffer and size inputs