### PR TITLE
[WFSSL-80] Add support for openssl 3.0.0

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/Messages.java
+++ b/java/src/main/java/org/wildfly/openssl/Messages.java
@@ -28,7 +28,7 @@ public class Messages {
 
     private static final String CODE = "WFOPENSSL";
 
-    public static Messages MESSAGES = new Messages();
+    public static final Messages MESSAGES = new Messages();
 
     private static final String MSG1 = formatCode(1);
     private static final String MSG2 = formatCode(2);

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLEngine.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLEngine.java
@@ -41,6 +41,7 @@ import static org.wildfly.openssl.SSL.SSL_PROTO_TLSv1_3;
 import static org.wildfly.openssl.SSL.VERSION_1_1_0;
 import static org.wildfly.openssl.SSL.VERSION_1_1_0_F;
 import static org.wildfly.openssl.SSL.VERSION_1_1_1;
+import static org.wildfly.openssl.SSL.VERSION_3_0_0;
 
 public final class OpenSSLEngine extends SSLEngine {
 
@@ -1536,6 +1537,14 @@ public final class OpenSSLEngine extends SSLEngine {
      */
     static boolean isOpenSSL111OrHigher() {
         return SSL.getInstance().versionNumber() >= VERSION_1_1_1;
+    }
+
+    /**
+     * Checks for OpenSSL 3.0.0 or higher
+     * @return If the openssl version is 3.0.0 or higher
+     */
+    static boolean isOpenSSL300OrHigher() {
+        return SSL.getInstance().versionNumber() >= VERSION_3_0_0;
     }
 
     static boolean isTLS13Supported() {

--- a/java/src/main/java/org/wildfly/openssl/SSL.java
+++ b/java/src/main/java/org/wildfly/openssl/SSL.java
@@ -46,8 +46,8 @@ public abstract class SSL {
     public static final String ORG_WILDFLY_OPENSSL_PATH_LIBCRYPTO = "org.wildfly.openssl.path.crypto";
     public static final String ORG_WILDFLY_LIBWFSSL_PATH = "org.wildfly.openssl.libwfssl.path";
 
-    private static final String[] LIBCRYPTO_NAMES = {"crypto.1.1", "libcrypto-1_1-x64", "crypto", "libeay32", "libcrypto-1_1"};
-    private static final String[] LIBSSL_NAMES = {"ssl.1.1", "libssl-1_1-x64", "ssl", "ssleay32", "libssl32", "libssl-1_1"};
+    private static final String[] LIBCRYPTO_NAMES = {"crypto.1.1", "libcrypto-1_1-x64", "libcrypto-3-x64", "crypto", "libeay32", "libcrypto-1_1"};
+    private static final String[] LIBSSL_NAMES = {"ssl.1.1", "libssl-1_1-x64", "libssl-3-x64", "ssl", "ssleay32", "libssl32", "libssl-1_1"};
 
     public SSL() {
     }
@@ -528,6 +528,7 @@ public abstract class SSL {
     static final long VERSION_1_1_0 = 0x10100000L;
     static final long VERSION_1_1_0_F = 0x1010006fL;
     static final long VERSION_1_1_1 = 0x10101000L;
+    static final long VERSION_3_0_0 = 0x30000000L;
 
     /* Return OpenSSL version number */
     protected abstract String version();

--- a/java/src/test/java/org/wildfly/openssl/AbstractOpenSSLTest.java
+++ b/java/src/test/java/org/wildfly/openssl/AbstractOpenSSLTest.java
@@ -18,6 +18,7 @@
 package org.wildfly.openssl;
 
 import org.junit.BeforeClass;
+import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL10;
 
 /**
  * @author Stuart Douglas
@@ -37,9 +38,7 @@ public class AbstractOpenSSLTest {
                 System.setProperty("javax.net.ssl.trustStore", "java/src/test/resources/client.truststore");
                 System.setProperty("javax.net.ssl.keyStorePassword", "password");
             }
-            final String openSSLVersion = SSL.getInstance().version();
-            // very crude (but acceptable) way to check the version
-            if (openSSLVersion.contains("1.0.2")) {
+            if (isOpenSSL10()) {
                 // 1.0.2 doesn't support "Extended master secret" extension, which is enabled in
                 // Java by default. here we disable that extension on the Java side to allow
                 // session resumption tests to pass

--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineLegacyProtocolsTest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLEngineLegacyProtocolsTest.java
@@ -19,13 +19,23 @@ package org.wildfly.openssl;
 
 import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL10;
 import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL110FOrLower;
+import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL300OrHigher;
+import static org.wildfly.openssl.OpenSSLEngine.isTLS13Supported;
 import static org.wildfly.openssl.OpenSSLProvider.getJavaSpecVersion;
+import static org.wildfly.openssl.SSL.SSL_PROTO_SSLv2;
 import static org.wildfly.openssl.SSL.SSL_PROTO_SSLv2Hello;
+import static org.wildfly.openssl.SSL.SSL_PROTO_SSLv3;
+import static org.wildfly.openssl.SSL.SSL_PROTO_TLSv1;
+import static org.wildfly.openssl.SSL.SSL_PROTO_TLSv1_1;
+import static org.wildfly.openssl.SSL.SSL_PROTO_TLSv1_2;
+import static org.wildfly.openssl.SSL.SSL_PROTO_TLSv1_3;
 
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.security.Security;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -52,7 +62,7 @@ public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  
     public static String disabledAlgorithms;
 
     // @SECLEVEL=1 is a needed directive to enable security level 1
-    private static String[] RSA_CIPHERS_SECLEVEL_1 = {
+    private static final String[] RSA_CIPHERS_SECLEVEL_1 = {
         "@SECLEVEL=1", "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
         "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
         "TLS_RSA_WITH_AES_256_CBC_SHA", "TLS_RSA_WITH_AES_128_CBC_SHA"
@@ -61,7 +71,7 @@ public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  
     @BeforeClass
     public static void setUp() {
         disabledAlgorithms = Security.getProperty("jdk.tls.disabledAlgorithms");
-        if (disabledAlgorithms != null && (disabledAlgorithms.contains("TLSv1") || disabledAlgorithms.contains("TLSv1.1"))) {
+        if (disabledAlgorithms != null && (disabledAlgorithms.contains(SSL_PROTO_TLSv1) || disabledAlgorithms.contains(SSL_PROTO_TLSv1_1))) {
             // reset the disabled algorithms to make sure that the protocols required in this test are available
             Security.setProperty("jdk.tls.disabledAlgorithms", "");
         }
@@ -74,9 +84,61 @@ public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  
         }
     }
 
+    private final String[] PROTOCOLS = {
+            SSL_PROTO_SSLv2,
+            SSL_PROTO_SSLv3,
+            SSL_PROTO_TLSv1,
+            SSL_PROTO_TLSv1_1,
+            SSL_PROTO_TLSv1_2,
+            SSL_PROTO_TLSv1_3
+    };
+
+    private String[] expectedEngineProtocols(String[] serverProtocols) {
+        int min = PROTOCOLS.length;
+        int max= -1;
+        for (String protocol : serverProtocols) {
+            for (int i = 0; i < PROTOCOLS.length; i++) {
+                if (PROTOCOLS[i].equals(protocol)) {
+                    if (i < min) {
+                        min = i;
+                    }
+                    if (i > max) {
+                        max = i;
+                    }
+                }
+            }
+        }
+        List<String> result = new ArrayList<>();
+        result.add(SSL_PROTO_SSLv2Hello);
+        for (int i = min; i <= max; i++) {
+            result.add(PROTOCOLS[i]);
+        }
+        return result.toArray(new String[0]);
+    }
+
+    private void testSocket(String protocol, String[] serverProtocols, AtomicReference<SSLEngine> engineRef, AtomicReference<byte[]> sessionID) throws IOException {
+        try (SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket()) {
+            socket.setReuseAddress(true);
+            socket.setEnabledProtocols(new String[]{protocol}); // from list of enabled protocols on the server side
+            socket.connect(SSLTestUtils.createSocketAddress());
+            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+            byte[] data = new byte[100];
+            int read = socket.getInputStream().read(data);
+
+            Assert.assertEquals(MESSAGE, new String(data, 0, read));
+            if (!SSL_PROTO_TLSv1_3.equals(protocol)) {
+                Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
+            }
+            Assert.assertEquals(protocol, socket.getSession().getProtocol());
+            Assert.assertArrayEquals(expectedEngineProtocols(serverProtocols), engineRef.get().getEnabledProtocols());
+            socket.getSession().invalidate();
+        }
+    }
+
     @Test
     public void testMultipleEnabledProtocolsWithClientProtocolExactMatch() throws IOException, InterruptedException {
-        final String[] protocols = new String[] { "TLSv1", "TLSv1.1" };
+        Assume.assumeTrue(!isOpenSSL300OrHigher());
+        final String[] protocols = new String[] { SSL_PROTO_TLSv1, SSL_PROTO_TLSv1_1 };
         try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
             final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
@@ -97,36 +159,38 @@ public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  
             Thread acceptThread = new Thread(echo);
             acceptThread.start();
 
-            SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-            socket.setReuseAddress(true);
-            socket.setEnabledProtocols(new String[]{"TLSv1"}); // from list of enabled protocols on the server side
-            socket.connect(SSLTestUtils.createSocketAddress());
-            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
-            byte[] data = new byte[100];
-            int read = socket.getInputStream().read(data);
+            testSocket(SSL_PROTO_TLSv1, protocols, engineRef, sessionID);
+            testSocket(SSL_PROTO_TLSv1_1, protocols, engineRef, sessionID);
 
-            Assert.assertEquals(MESSAGE, new String(data, 0, read));
-            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
-            Assert.assertEquals("TLSv1", socket.getSession().getProtocol());
-            Assert.assertArrayEquals(new String[]{SSL_PROTO_SSLv2Hello, "TLSv1", "TLSv1.1"}, engineRef.get().getEnabledProtocols());
-            socket.getSession().invalidate();
-            socket.close();
+            serverSocket.close();
+            acceptThread.join();
+        }
+    }
 
-            socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-            socket.setReuseAddress(true);
-            socket.setEnabledProtocols(new String[]{"TLSv1.1"}); // from list of enabled protocols on the server side
-            socket.connect(SSLTestUtils.createSocketAddress());
-            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
-            data = new byte[100];
-            read = socket.getInputStream().read(data);
+    @Test
+    public void testMultipleEnabledProtocolsWithClientProtocolExactMatchTls13() throws IOException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        final String[] protocols = new String[] { SSL_PROTO_TLSv1_2, SSL_PROTO_TLSv1_3 };
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
+            final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
 
-            Assert.assertEquals(MESSAGE, new String(data, 0, read));
-            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
-            Assert.assertEquals("TLSv1.1", socket.getSession().getProtocol());
-            Assert.assertArrayEquals(new String[]{SSL_PROTO_SSLv2Hello, "TLSv1", "TLSv1.1"}, engineRef.get().getEnabledProtocols());
+            EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
+                engineRef.set(engine);
+                try {
+                    engine.setEnabledProtocols(protocols);
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Thread acceptThread = new Thread(echo);
+            acceptThread.start();
 
-            socket.getSession().invalidate();
-            socket.close();
+            testSocket(SSL_PROTO_TLSv1_2, protocols, engineRef, sessionID);
+            testSocket(SSL_PROTO_TLSv1_3, protocols, engineRef, sessionID);
+
             serverSocket.close();
             acceptThread.join();
         }
@@ -134,8 +198,8 @@ public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  
 
     @Test
     public void testMultipleEnabledProtocolsWithClientProtocolWithinEnabledRange() throws IOException, InterruptedException {
-        Assume.assumeTrue(! isOpenSSL10() && ! isOpenSSL110FOrLower());
-        final String[] protocols = new String[] { "TLSv1", "TLSv1.2" };
+        Assume.assumeTrue(! isOpenSSL10() && ! isOpenSSL110FOrLower() && ! isOpenSSL300OrHigher());
+        final String[] protocols = new String[] { SSL_PROTO_TLSv1, SSL_PROTO_TLSv1_2 };
         try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
             final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
@@ -156,21 +220,36 @@ public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  
             Thread acceptThread = new Thread(echo);
             acceptThread.start();
 
-            SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-            socket.setReuseAddress(true);
-            socket.setEnabledProtocols(new String[] { "TLSv1.1" });
-            socket.connect(SSLTestUtils.createSocketAddress());
-            socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
-            byte[] data = new byte[100];
-            int read = socket.getInputStream().read(data);
+            testSocket(SSL_PROTO_TLSv1_1, protocols, engineRef, sessionID);
 
-            Assert.assertEquals(MESSAGE, new String(data, 0, read));
-            Assert.assertArrayEquals(socket.getSession().getId(), sessionID.get());
-            Assert.assertEquals("TLSv1.1", socket.getSession().getProtocol());
-            Assert.assertArrayEquals(new String[]{SSL_PROTO_SSLv2Hello, "TLSv1", "TLSv1.1", "TLSv1.2"}, engineRef.get().getEnabledProtocols());
+            serverSocket.close();
+            acceptThread.join();
+        }
+    }
 
-            socket.getSession().invalidate();
-            socket.close();
+    @Test
+    public void testMultipleEnabledProtocolsWithClientProtocolWithinEnabledRangeTls13() throws IOException, InterruptedException {
+        Assume.assumeTrue(isTLS13Supported());
+        final String[] protocols = new String[] { SSL_PROTO_TLSv1_1, SSL_PROTO_TLSv1_3 };
+        try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
+            final AtomicReference<byte[]> sessionID = new AtomicReference<>();
+            final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
+            final AtomicReference<SSLEngine> engineRef = new AtomicReference<>();
+
+            EchoRunnable echo = new EchoRunnable(serverSocket, sslContext, sessionID, (engine -> {
+                engineRef.set(engine);
+                try {
+                    engine.setEnabledProtocols(protocols);
+                    return engine;
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            Thread acceptThread = new Thread(echo);
+            acceptThread.start();
+
+            testSocket(SSL_PROTO_TLSv1_2, protocols, engineRef, sessionID);
+
             serverSocket.close();
             acceptThread.join();
         }
@@ -178,7 +257,7 @@ public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  
 
     @Test
     public void testMultipleEnabledProtocolsWithClientProtocolOutsideOfEnabledRange() throws IOException, InterruptedException {
-        final String[] protocols = new String[]{"TLSv1.1", "TLSv1.2"};
+        final String[] protocols = new String[]{SSL_PROTO_TLSv1_1, SSL_PROTO_TLSv1_2};
         try (ServerSocket serverSocket = SSLTestUtils.createServerSocket()) {
             final AtomicReference<byte[]> sessionID = new AtomicReference<>();
             final SSLContext sslContext = SSLTestUtils.createSSLContext("openssl.TLS");
@@ -199,47 +278,25 @@ public class BasicOpenSSLEngineLegacyProtocolsTest extends AbstractOpenSSLTest  
             Thread acceptThread = new Thread(echo);
             acceptThread.start();
 
-            SSLSocket socket = null;
             try {
-                socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-                socket.setReuseAddress(true);
-                socket.setEnabledProtocols(new String[]{"SSLv3"});
-                socket.connect(SSLTestUtils.createSocketAddress());
-                socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+                testSocket(SSL_PROTO_SSLv3, protocols, engineRef, sessionID);
                 Assert.fail("Expected SSLHandshakeException not thrown");
             } catch (SSLHandshakeException e) {
                 // expected
-                if (socket != null) {
-                    socket.close();
-                }
             }
             try {
-                socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-                socket.setReuseAddress(true);
-                socket.setEnabledProtocols(new String[]{"TLSv1"});
-                socket.connect(SSLTestUtils.createSocketAddress());
-                socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+                testSocket(SSL_PROTO_TLSv1, protocols, engineRef, sessionID);
                 Assert.fail("Expected SSLHandshakeException not thrown");
             } catch (SSLHandshakeException e) {
                 // expected
-                if (socket != null) {
-                    socket.close();
-                }
             }
             try {
                 if (getJavaSpecVersion() >= 11) {
-                    socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
-                    socket.setReuseAddress(true);
-                    socket.setEnabledProtocols(new String[]{"TLSv1.3"});
-                    socket.connect(SSLTestUtils.createSocketAddress());
-                    socket.getOutputStream().write(MESSAGE.getBytes(StandardCharsets.US_ASCII));
+                    testSocket(SSL_PROTO_TLSv1_3, protocols, engineRef, sessionID);
                     Assert.fail("Expected SSLHandshakeException not thrown");
                 }
             } catch (SSLHandshakeException e) {
                 // expected
-                if (socket != null) {
-                    socket.close();
-                }
             }
 
             serverSocket.close();

--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketDSATest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketDSATest.java
@@ -26,11 +26,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
+import static org.wildfly.openssl.OpenSSLEngine.isOpenSSL10;
 
 /**
  * @author Stuart Douglas
@@ -38,8 +38,7 @@ import org.junit.Test;
 public class BasicOpenSSLSocketDSATest extends AbstractOpenSSLTest {
     @Before
     public void testOpenSSLVersion() {
-        String openSSLVersion = SSL.getInstance().version().split(" ")[1];
-        Assume.assumeThat(openSSLVersion.startsWith("1.1."), CoreMatchers.is(false));
+        Assume.assumeTrue(isOpenSSL10());
     }
 
     @Test


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFSSL-80

The change modifies the wildfly-openssl java project to make openssl 3.0.0 pass all the tests. The change between natives and java part are not dependent. But you need both to make openssl 3.0.0 work and pass all the tests (the java part should upgrade to a new natives version in order to pass the tests with version 3.0.0).