### PR TITLE
[WFSSL-114] Upgrade to JUnit 4.13.2

### DIFF
--- a/java/src/test/java/org/wildfly/openssl/TestAllMethodsImplemented.java
+++ b/java/src/test/java/org/wildfly/openssl/TestAllMethodsImplemented.java
@@ -29,8 +29,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.junit.Assert;
-import org.junit.internal.matchers.StringContains;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.StringContains;
 
 /**
  * A really hacky test that all methods are implemented
@@ -82,7 +82,7 @@ public class TestAllMethodsImplemented extends AbstractOpenSSLTest  {
             while (rootCause.getCause() != null) {
                 rootCause = rootCause.getCause();
             }
-            Assert.assertThat(rootCause.getMessage(), StringContains.containsString(":no cipher match:"));
+            MatcherAssert.assertThat(rootCause.getMessage(), StringContains.containsString(":no cipher match:"));
             throw e;
         } finally {
             if (ssl != null && ctx != 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <properties>
         <jdk.min.version>11</jdk.min.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.junit.junit>4.13.2</version.junit.junit>
         <version.org.wildfly.checkstyle>1.0.8.Final</version.org.wildfly.checkstyle>
         <version.org.wildfly.openssl.natives>2.2.2.Final</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
@@ -63,7 +64,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.8.2</version>
+                <version>${version.junit.junit}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFSSL-114

Upgrade for JUnit from 4.8.2 to 4.13.2. I also moved the version to a variable like we usually do (e.g. the elytron project).