### PR TITLE
Support for LoongArch64

### DIFF
--- a/combined/pom.xml
+++ b/combined/pom.xml
@@ -99,6 +99,22 @@
             </dependencies>
         </profile>
         <profile>
+            <id>linux-loongarch64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>loongarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.openssl</groupId>
+                    <artifactId>wildfly-openssl-linux-loongarch64</artifactId>
+                    <version>${version.org.wildfly.openssl.natives}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>linux-ppc64le</id>
             <activation>
                 <os>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -199,6 +199,23 @@
             </dependencies>
         </profile>
         <profile>
+            <id>linux-loongarch64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>loongarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.openssl</groupId>
+                    <artifactId>wildfly-openssl-linux-loongarch64</artifactId>
+                    <version>${version.org.wildfly.openssl.natives}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>linux-ppc64le</id>
             <activation>
                 <os>

--- a/java/src/main/java/org/wildfly/openssl/Identification.java
+++ b/java/src/main/java/org/wildfly/openssl/Identification.java
@@ -155,6 +155,9 @@ class Identification {
                         } else if (sysArch.startsWith("AARCH64") || sysArch.startsWith("ARM64") || sysArch.startsWith("ARMV8") || sysArch.startsWith("PXA9") || sysArch.startsWith("PXA10")) {
                             hasEndian = true;
                             cpuName = "aarch64";
+                        } else if (sysArch.startsWith("LOONGARCH64")) {
+                            hasEndian = true;
+                            cpuName = "loongarch64";
                         } else if (sysArch.startsWith("PXA27")) {
                             hasEndian = true;
                             cpuName = "armv5t-iwmmx";

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.junit.junit>4.13.2</version.junit.junit>
         <version.org.wildfly.checkstyle>1.0.8.Final</version.org.wildfly.checkstyle>
-        <version.org.wildfly.openssl.natives>2.2.2.Final</version.org.wildfly.openssl.natives>
+	<version.org.wildfly.openssl.natives>2.2.3.CR1-SNAPSHOT</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-s390x>2.2.2.SP01</version.org.wildfly.openssl.wildfly-openssl-linux-s390x>
         <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>


### PR DESCRIPTION
LoongArch is a risc architecture, like RISCV. This PR is used to support LoongArch.