### PR TITLE
Add loongarch64 support

### DIFF
--- a/combined/pom.xml
+++ b/combined/pom.xml
@@ -99,6 +99,22 @@
             </dependencies>
         </profile>
         <profile>
+            <id>linux-loongarch64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>loongarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.openssl</groupId>
+                    <artifactId>wildfly-openssl-linux-loongarch64</artifactId>
+                    <version>${version.org.wildfly.openssl.natives}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>linux-ppc64le</id>
             <activation>
                 <os>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -199,6 +199,23 @@
             </dependencies>
         </profile>
         <profile>
+            <id>linux-loongarch64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>loongarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.openssl</groupId>
+                    <artifactId>wildfly-openssl-linux-loongarch64</artifactId>
+                    <version>${version.org.wildfly.openssl.natives}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>linux-ppc64le</id>
             <activation>
                 <os>

--- a/java/src/main/java/org/wildfly/openssl/Identification.java
+++ b/java/src/main/java/org/wildfly/openssl/Identification.java
@@ -155,6 +155,9 @@ class Identification {
                         } else if (sysArch.startsWith("AARCH64") || sysArch.startsWith("ARM64") || sysArch.startsWith("ARMV8") || sysArch.startsWith("PXA9") || sysArch.startsWith("PXA10")) {
                             hasEndian = true;
                             cpuName = "aarch64";
+                        } else if (sysArch.startsWith("LOONGARCH64")) {
+                            hasEndian = true;
+                            cpuName = "loongarch64";
                         } else if (sysArch.startsWith("PXA27")) {
                             hasEndian = true;
                             cpuName = "armv5t-iwmmx";


### PR DESCRIPTION
LoongArch is a risc architecture, like RISCV. This PR is used to support LoongArch.