### PR TITLE
fix: avoid never ending loop when peer sends close notify during TLS handshake

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
@@ -303,6 +303,10 @@ public class OpenSSLSocket extends SSLSocket {
                 if (write) {
                     buffer.clear();
                     result = sslEngine.wrap(EMPTY_DIRECT, buffer);
+                    if (result.getStatus() == SSLEngineResult.Status.CLOSED) {
+                        close();
+                        throw new SSLException(MESSAGES.connectionClosed());
+                    }
                     if (result.bytesProduced() > 0) {
                         buffer.flip();
                         try (DefaultByteBufferPool.PooledByteBuffer indirectPooled = DefaultByteBufferPool.HEAP_POOL.allocate()) {
@@ -336,6 +340,10 @@ public class OpenSSLSocket extends SSLSocket {
                                 buffer.put(indirectPooled.getBuffer());
                                 buffer.flip();
                                 result = sslEngine.unwrap(buffer, unwrappedData.getBuffer());
+                                if (result.getStatus() == SSLEngineResult.Status.CLOSED) {
+                                    close();
+                                    throw new SSLException(MESSAGES.connectionClosed());
+                                }
                                 if(result.getStatus() == SSLEngineResult.Status.BUFFER_UNDERFLOW) {
                                     underflow = true;
                                 }


### PR DESCRIPTION
When acting as a client, if the peer sends a closeNotify message during the TLS handshake, a bug may occur in which wildfly becomes stuck in the `unwrap` or `wrap` functions. This happens because the underlying `sslEngine.[un]wrap` functions eventually return a result with status CLOSED and with 0 bytes consumed, but the caller does not handle it properly, and simply proceed to the next iteration even though no data was consumed.

This issue is easily reproduced by setting up a custom TLS server that forcefully emits closeNotify messages during the handshake, using wildfly engine as a client connection, and observing the behavior.

The proposed modifications seems to fix the issue.