### PR TITLE
Amend readme for nonintels and older systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Building
 The java side of the project uses maven and can be build as normal (`mvn install`). The native code should be build
 as part of the standard build process.
 
+Note, that if you are not on intel machine, or you are on older system like rhel7, you have to first self build [wildfly-openssl-natives](../wildfly-openssl-natives?tab=readme-ov-file#building).
+
 ### Windows
 
 To do the Windows build you need to run the build from a visual studio native tools command prompt. If you want to build

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The java side of the project uses maven and can be build as normal (`mvn install
 as part of the standard build process.
 
 Note, that if you are not on intel machine, or you are on older system like RHEL-8, you have to first self build [wildfly-openssl-natives](https://github.com/wildfly-security/wildfly-openssl-natives/?tab=readme-ov-file#building).
+ * errors like `[ERROR] dependency: org.wildfly.openssl:wildfly-openssl-linux-aarch64:jar:2.3.0.Alpha3 was not found in https://repo...`
+   * means the native artifacts are missing for your platfrom, you have to self-build them.
+ * error like `/tmp/.../libwfssl.so: /lib64/libc.so.6: version GLIBC_2.34 not found (required by /tmp/.../libwfssl.so)`
+   * means that you are on the older system then the natives built for you in public repos, and so you have to self-build them.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Building
 The java side of the project uses maven and can be build as normal (`mvn install`). The native code should be build
 as part of the standard build process.
 
-Note, that if you are not on intel machine, or you are on older system like rhel7, you have to first self build [wildfly-openssl-natives](../wildfly-openssl-natives?tab=readme-ov-file#building).
+Note, that if you are not on intel machine, or you are on older system like rhel7, you have to first self build [wildfly-openssl-natives](../../wildfly-openssl-natives?tab=readme-ov-file#building).
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Building
 The java side of the project uses maven and can be build as normal (`mvn install`). The native code should be build
 as part of the standard build process.
 
-Note, that if you are not on intel machine, or you are on older system like rhel7, you have to first self build [wildfly-openssl-natives](https://github.com/wildfly-security/wildfly-openssl-natives/?tab=readme-ov-file#building).
+Note, that if you are not on intel machine, or you are on older system like RHEL-8, you have to first self build [wildfly-openssl-natives](https://github.com/wildfly-security/wildfly-openssl-natives/?tab=readme-ov-file#building).
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Building
 The java side of the project uses maven and can be build as normal (`mvn install`). The native code should be build
 as part of the standard build process.
 
-Note, that if you are not on intel machine, or you are on older system like rhel7, you have to first self build [wildfly-openssl-natives](../../wildfly-openssl-natives?tab=readme-ov-file#building).
+Note, that if you are not on intel machine, or you are on older system like rhel7, you have to first self build [wildfly-openssl-natives](https://github.com/wildfly-security/wildfly-openssl-natives/?tab=readme-ov-file#building).
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Building
 The java side of the project uses maven and can be build as normal (`mvn install`). The native code should be build
 as part of the standard build process.
 
-Note, that if you are not on intel machine, or you are on older system like RHEL-8, you have to first self build [wildfly-openssl-natives](https://github.com/wildfly-security/wildfly-openssl-natives/?tab=readme-ov-file#building).
+Note, that if you are not on x86_64 machine, or you are on older system like RHEL-8, you have to first self build [wildfly-openssl-natives](https://github.com/wildfly-security/wildfly-openssl-natives/?tab=readme-ov-file#building).
  * errors like `[ERROR] dependency: org.wildfly.openssl:wildfly-openssl-linux-aarch64:jar:2.3.0.Alpha3 was not found in https://repo...`
    * means the native artifacts are missing for your platfrom, you have to self-build them.
  * error like `/tmp/.../libwfssl.so: /lib64/libc.so.6: version GLIBC_2.34 not found (required by /tmp/.../libwfssl.so)`


### PR DESCRIPTION
On non-intels, the wildfly-openssl-natives are simpli not available from default repos, and having that mentioned will save few minutes to people in quick need of self build of this library. In addition, the build of wildfly-openssl-natives/ is not strightforward, see https://github.com/wildfly-security/wildfly-openssl-natives/pull/45

Similarly, the intel wildfly-openssl-natives are built against quite new glibc: `/libwfssl.so: /lib64/libc.so.6: version GLIBC_2.34 not found` is easy to hit on el7 or el8.